### PR TITLE
Add unit semantic convention generator

### DIFF
--- a/semantic-conventions/src/opentelemetry/semconv/main.py
+++ b/semantic-conventions/src/opentelemetry/semconv/main.py
@@ -48,20 +48,13 @@ def exclude_file_list(folder: str, pattern: str) -> List[str]:
     return file_names
 
 
-def filter_semconv(
-    semconv: SemanticConventionSet, span: bool, resource: bool, metric: bool
-):
-    if span or resource or metric:
-        output = {}
-        for semconv_id in semconv.models:
-            model = semconv.models[semconv_id]
-            if span and model.type == "span":
-                output[semconv_id] = model
-            if resource and model.type == "resource":
-                output[semconv_id] = model
-            if metric and model.type == "metric":
-                output[semconv_id] = model
-        semconv.models = output
+def filter_semconv(semconv, type_filter):
+    if type_filter:
+        semconv.models = {
+            id: model
+            for id, model in semconv.models.items()
+            if model.TYPE_VALUE == type_filter
+        }
 
 
 def main():
@@ -69,7 +62,7 @@ def main():
     args = parser.parse_args()
     check_args(args, parser)
     semconv = parse_semconv(args, parser)
-    filter_semconv(semconv, args.span, args.resource, args.metric)
+    filter_semconv(semconv, args.only)
     if len(semconv.models) == 0:
         parser.error("No semantic convention model found!")
     if args.flavor == "code":
@@ -172,22 +165,9 @@ def setup_parser():
         "--debug", "-d", help="Enable debug output", action="store_true"
     )
     parser.add_argument(
-        "--span",
-        "-s",
-        help="Process only Span semantic conventions",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--resource",
-        "-r",
-        help="Process only Resource semantic conventions",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--metric",
-        "-m",
-        help="Process only Metric semantic conventions",
-        action="store_true",
+        "--only",
+        choices=["span", "resource", "metric", "units"],
+        help="Process only semantic conventions of the specified type.",
     )
     parser.add_argument(
         "--yaml-root",

--- a/semantic-conventions/src/opentelemetry/semconv/main.py
+++ b/semantic-conventions/src/opentelemetry/semconv/main.py
@@ -53,7 +53,7 @@ def filter_semconv(semconv, type_filter):
         semconv.models = {
             id: model
             for id, model in semconv.models.items()
-            if model.TYPE_VALUE == type_filter
+            if model.GROUP_TYPE_NAME == type_filter
         }
 
 

--- a/semantic-conventions/src/opentelemetry/semconv/main.py
+++ b/semantic-conventions/src/opentelemetry/semconv/main.py
@@ -19,10 +19,7 @@ import glob
 import sys
 from typing import List
 
-from opentelemetry.semconv.model.semantic_convention import (
-    SemanticConventionSet,
-    SemanticConventionType,
-)
+from opentelemetry.semconv.model.semantic_convention import SemanticConventionSet
 from opentelemetry.semconv.templating.code import CodeRenderer
 
 from opentelemetry.semconv.templating.markdown import MarkdownRenderer
@@ -58,11 +55,11 @@ def filter_semconv(
         output = {}
         for semconv_id in semconv.models:
             model = semconv.models[semconv_id]
-            if span and model.type == SemanticConventionType.SPAN:
+            if span and model.type == "span":
                 output[semconv_id] = model
-            if resource and model.type == SemanticConventionType.RESOURCE:
+            if resource and model.type == "resource":
                 output[semconv_id] = model
-            if metric and model.type == SemanticConventionType.METRIC:
+            if metric and model.type == "metric":
                 output[semconv_id] = model
         semconv.models = output
 

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
@@ -35,6 +35,18 @@ class Required(Enum):
     NO = 3
 
 
+class HasAttributes:
+    def _set_attributes(self, prefix, node):
+        self.attrs_by_name = SemanticAttribute.parse(prefix, node.get("attributes"))
+
+    @property
+    def attributes(self):
+        if not hasattr(self, "attrs_by_name"):
+            return []
+
+        return list(self.attrs_by_name.values())
+
+
 @dataclass
 class SemanticAttribute:
     fqn: str

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
@@ -47,6 +47,14 @@ class HasAttributes:
         return list(self.attrs_by_name.values())
 
 
+def unique_attributes(attributes):
+    output = []
+    for x in l:
+        if x.fqn not in [attr.fqn for attr in output]:
+            output.append(x)
+    return output
+
+
 @dataclass
 class SemanticAttribute:
     fqn: str

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
@@ -85,6 +85,9 @@ class SemanticAttribute:
             "sampling_relevant",
             "note",
         )
+        if not yaml_attributes:
+            return attributes
+
         for attribute in yaml_attributes:
             validate_values(attribute, allowed_keys)
             attr_id = attribute.get("id")

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -62,10 +62,13 @@ def parse_semantic_convention_type(type_value):
     if type_value is None:
         return SpanSemanticConvention
     enum_map = {
-        "span": SpanSemanticConvention,
-        "resource": ResourceSemanticConvention,
-        "metric": MetricSemanticConvention,
-        "units": UnitSemanticConvention,
+        cls.TYPE_VALUE: cls
+        for cls in [
+            SpanSemanticConvention,
+            ResourceSemanticConvention,
+            MetricSemanticConvention,
+            UnitSemanticConvention,
+        ]
     }
     return enum_map.get(type_value)
 
@@ -98,7 +101,7 @@ def SemanticConvention(group):
     # First, validate that the correct fields are available in the yaml
     convention_type.validate_keys(group)
     model = convention_type(group)
-    # Also, validate that the value of the fields is acceptable
+    # Also, va`lidate that the value of the fields is acceptable
     model.validate_values()
     return model
 
@@ -176,6 +179,8 @@ class BaseSemanticConvention(ValidatableYamlNode):
 
 
 class ResourceSemanticConvention(HasAttributes, BaseSemanticConvention):
+    TYPE_VALUE = "resource"
+
     allowed_keys = (
         "id",
         "type",
@@ -193,6 +198,8 @@ class ResourceSemanticConvention(HasAttributes, BaseSemanticConvention):
 
 
 class SpanSemanticConvention(HasAttributes, BaseSemanticConvention):
+    TYPE_VALUE = "span"
+
     allowed_keys = (
         "id",
         "type",
@@ -216,6 +223,8 @@ class SpanSemanticConvention(HasAttributes, BaseSemanticConvention):
 
 
 class UnitSemanticConvention(BaseSemanticConvention):
+    TYPE_VALUE = "units"
+
     allowed_keys = (
         "id",
         "type",
@@ -229,6 +238,8 @@ class UnitSemanticConvention(BaseSemanticConvention):
 
 
 class MetricSemanticConvention(BaseSemanticConvention):
+    TYPE_VALUE = "metric"
+
     allowed_keys = []
 
 

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -261,8 +261,13 @@ class UnitSemanticConvention(SemanticConvention):
         "id",
         "type",
         "brief",
-        "fields",
+        "members",
     ]
+
+    def __init__(self, group):
+        super(UnitSemanticConvention, self).__init__(group)
+        self.members = UnitMember.parse(group.get("members"))
+
 
 
 class MetricSemanticConvention(SemanticConvention):

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -62,7 +62,7 @@ def parse_semantic_convention_type(type_value):
     if type_value is None:
         return SpanSemanticConvention
     enum_map = {
-        cls.TYPE_VALUE: cls
+        cls.GROUP_TYPE_NAME: cls
         for cls in [
             SpanSemanticConvention,
             ResourceSemanticConvention,
@@ -101,7 +101,7 @@ def SemanticConvention(group):
     # First, validate that the correct fields are available in the yaml
     convention_type.validate_keys(group)
     model = convention_type(group)
-    # Also, va`lidate that the value of the fields is acceptable
+    # Also, validate that the value of the fields is acceptable
     model.validate_values()
     return model
 
@@ -179,7 +179,7 @@ class BaseSemanticConvention(ValidatableYamlNode):
 
 
 class ResourceSemanticConvention(HasAttributes, BaseSemanticConvention):
-    TYPE_VALUE = "resource"
+    GROUP_TYPE_NAME = "resource"
 
     allowed_keys = (
         "id",
@@ -198,7 +198,7 @@ class ResourceSemanticConvention(HasAttributes, BaseSemanticConvention):
 
 
 class SpanSemanticConvention(HasAttributes, BaseSemanticConvention):
-    TYPE_VALUE = "span"
+    GROUP_TYPE_NAME = "span"
 
     allowed_keys = (
         "id",
@@ -223,7 +223,7 @@ class SpanSemanticConvention(HasAttributes, BaseSemanticConvention):
 
 
 class UnitSemanticConvention(BaseSemanticConvention):
-    TYPE_VALUE = "units"
+    GROUP_TYPE_NAME = "units"
 
     allowed_keys = (
         "id",
@@ -238,7 +238,7 @@ class UnitSemanticConvention(BaseSemanticConvention):
 
 
 class MetricSemanticConvention(BaseSemanticConvention):
-    TYPE_VALUE = "metric"
+    GROUP_TYPE_NAME = "metric"
 
     allowed_keys = []
 

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -220,8 +220,7 @@ class SemanticConvention(ValidatableYamlNode):
 
 
 class ResourceSemanticConvention(HasAttributes, SemanticConvention):
-
-    allowed_keys = [
+    allowed_keys = (
         "id",
         "type",
         "brief",
@@ -230,15 +229,15 @@ class ResourceSemanticConvention(HasAttributes, SemanticConvention):
         "extends",
         "attributes",
         "constraints",
-    ]
+    )
 
     def __init__(self, group):
-        super(ResourceSemanticConvention, self).__init__(group)
+        super().__init__(group)
         self._set_attributes(self.prefix, group)
 
 
 class SpanSemanticConvention(HasAttributes, SemanticConvention):
-    allowed_keys = [
+    allowed_keys = (
         "id",
         "type",
         "brief",
@@ -248,24 +247,24 @@ class SpanSemanticConvention(HasAttributes, SemanticConvention):
         "span_kind",
         "attributes",
         "constraints",
-    ]
+    )
 
     def __init__(self, group):
-        super(SpanSemanticConvention, self).__init__(group)
+        super().__init__(group)
         self._set_attributes(self.prefix, group)
         self.span_kind = SpanKind.parse(group.get("span_kind"))
 
 
 class UnitSemanticConvention(SemanticConvention):
-    allowed_keys = [
+    allowed_keys = (
         "id",
         "type",
         "brief",
         "members",
-    ]
+    )
 
     def __init__(self, group):
-        super(UnitSemanticConvention, self).__init__(group)
+        super().__init__(group)
         self.members = UnitMember.parse(group.get("members"))
 
 

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -80,7 +80,7 @@ class SemanticConvention(ValidatableYamlNode):
 
         self.semconv_id = self.id
         self.note = group.get("note", "").strip()
-        self.prefix = group.get("prefix", "")
+        self.prefix = group.get("prefix", "").strip()
         self.extends = group.get("extends", "").strip()
         self.constraints = SemanticConvention.parse_constraint(
             group.get("constraints", ())

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -240,7 +240,7 @@ class UnitSemanticConvention(BaseSemanticConvention):
 class MetricSemanticConvention(BaseSemanticConvention):
     GROUP_TYPE_NAME = "metric"
 
-    allowed_keys = []
+    allowed_keys = ()
 
 
 @dataclass

--- a/semantic-conventions/src/opentelemetry/semconv/model/unit_member.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/unit_member.py
@@ -1,0 +1,22 @@
+from opentelemetry.semconv.model.utils import ValidatableYamlNode
+
+
+class UnitMember(ValidatableYamlNode):
+
+    allowed_keys = ["id", "brief", "value"]
+    mandatory_keys = allowed_keys
+
+    def __init__(self, node):
+        super(UnitMember, self).__init__(node)
+        self.value = node.get("value")
+
+    @staticmethod
+    def parse(members):
+        parsed_members = {}
+        for member in members:
+            UnitMember.validate_keys(member)
+            unit_member = UnitMember(member)
+            unit_member.validate_values()
+            parsed_members[unit_member.id] = unit_member
+
+        return parsed_members

--- a/semantic-conventions/src/opentelemetry/semconv/model/unit_member.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/unit_member.py
@@ -3,11 +3,11 @@ from opentelemetry.semconv.model.utils import ValidatableYamlNode
 
 class UnitMember(ValidatableYamlNode):
 
-    allowed_keys = ["id", "brief", "value"]
+    allowed_keys = ("id", "brief", "value")
     mandatory_keys = allowed_keys
 
     def __init__(self, node):
-        super(UnitMember, self).__init__(node)
+        super().__init__(node)
         self.value = node.get("value")
 
     @staticmethod

--- a/semantic-conventions/src/opentelemetry/semconv/model/utils.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/utils.py
@@ -52,8 +52,8 @@ def check_no_missing_keys(yaml, mandatory):
 
 class ValidatableYamlNode:
 
-    allowed_keys = []
-    mandatory_keys = ["id", "brief"]
+    allowed_keys = ()
+    mandatory_keys = ("id", "brief")
 
     def __init__(self, yaml_node):
         self.id = yaml_node.get("id").strip()

--- a/semantic-conventions/src/opentelemetry/semconv/model/utils.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/utils.py
@@ -48,3 +48,34 @@ def check_no_missing_keys(yaml, mandatory):
         position = yaml.lc.data[list(yaml)[0]]
         msg = "Missing keys: {}".format(missing)
         raise ValidationError.from_yaml_pos(position, msg)
+
+
+class ValidatableYamlNode:
+
+    allowed_keys = []
+    mandatory_keys = ["id", "brief"]
+
+    def __init__(self, yaml_node):
+        self.id = yaml_node.get("id").strip()
+        self.brief = str(yaml_node.get("brief")).strip()
+
+        self._position = [yaml_node.lc.line, yaml_node.lc.col]
+
+    @classmethod
+    def validate_keys(cls, node):
+        unwanted = [key for key in node.keys() if key not in cls.allowed_keys]
+        if unwanted:
+            position = node.lc.data[unwanted[0]]
+            msg = "Invalid keys: {}".format(unwanted)
+            raise ValidationError.from_yaml_pos(position, msg)
+
+        if cls.mandatory_keys:
+            check_no_missing_keys(node, cls.mandatory_keys)
+
+    def validate_values(self):
+        """
+        Subclasses may provide additional validation. 
+        This method should raise an exception with a descriptive
+        message if the semantic convention is not valid.
+        """
+        validate_id(self.id, self._position)

--- a/semantic-conventions/src/opentelemetry/semconv/templating/code.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/code.py
@@ -19,10 +19,7 @@ import typing
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
-from opentelemetry.semconv.model.semantic_convention import (
-    SemanticConventionSet,
-    SemanticConvention,
-)
+from opentelemetry.semconv.model.semantic_convention import SemanticConventionSet
 from opentelemetry.semconv.model.utils import ID_RE
 
 
@@ -84,9 +81,7 @@ class CodeRenderer:
         data.update(self.parameters)
         return data
 
-    def get_data_multiple_files(
-        self, semconv: SemanticConvention, template_path: str
-    ) -> dict:
+    def get_data_multiple_files(self, semconv, template_path) -> dict:
         """Returns a dictionary with the data from a single SemanticConvention to fill the template."""
         data = {"template": template_path, "semconv": semconv}
         data.update(self.parameters)
@@ -100,7 +95,7 @@ class CodeRenderer:
         env.filters["to_camelcase"] = to_camelcase
 
     @staticmethod
-    def prefix_output_file(file_name: str, pattern: str, semconv: SemanticConvention):
+    def prefix_output_file(file_name, pattern, semconv):
         base = os.path.basename(file_name)
         dir = os.path.dirname(file_name)
         value = getattr(semconv, pattern)
@@ -121,7 +116,6 @@ class CodeRenderer:
         )
         self.setup_environment(env)
         if pattern:
-            semconv: SemanticConvention
             for semconv in semconvset.models.values():
                 output_name = self.prefix_output_file(output_file, pattern, semconv)
                 data = self.get_data_multiple_files(semconv, template_path)

--- a/semantic-conventions/src/opentelemetry/semconv/templating/markdown.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/markdown.py
@@ -30,6 +30,7 @@ from opentelemetry.semconv.model.semantic_attribute import (
 from opentelemetry.semconv.model.semantic_convention import (
     SemanticConventionSet,
     SemanticConvention,
+    UnitSemanticConvention
 )
 from opentelemetry.semconv.model.utils import ID_RE
 
@@ -51,6 +52,7 @@ class RenderContext:
         self.break_count = break_count
         self.enums = []
         self.notes = []
+        self.units = []
         self.current_md = ""
         self.current_semconv = None
 
@@ -185,6 +187,15 @@ class MarkdownRenderer:
         for note in self.render_ctx.notes:
             output.write("\n**[{}]:** {}\n".format(counter, note))
             counter += 1
+
+    def to_markdown_unit_table(self, members, output):
+        output.write('\n')
+        output.write(
+            '| Name        | Kind of Quantity         | Unit String   |\n'
+            '| ------------| ----------------         | -----------   |')
+        for member in members.values():
+            output.write('\n| {} | {} | `{}` |'.format(member.id, member.brief, member.value))
+        output.write('\n')
 
     def to_markdown_enum(self, output: io.StringIO):
         """ Renders enum types after a Semantic Convention Table
@@ -394,5 +405,8 @@ class MarkdownRenderer:
             for cnst in semconv.constraints:
                 self.to_markdown_constraint(cnst, output)
         self.to_markdown_enum(output)
+        
+        if isinstance(semconv, UnitSemanticConvention):
+            self.to_markdown_unit_table(semconv.members, output)
 
         output.write("<!-- endsemconv -->")

--- a/semantic-conventions/src/opentelemetry/semconv/templating/markdown.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/markdown.py
@@ -29,8 +29,7 @@ from opentelemetry.semconv.model.semantic_attribute import (
 )
 from opentelemetry.semconv.model.semantic_convention import (
     SemanticConventionSet,
-    SemanticConvention,
-    UnitSemanticConvention
+    UnitSemanticConvention,
 )
 from opentelemetry.semconv.model.utils import ID_RE
 
@@ -43,7 +42,6 @@ class RenderContext:
     enums: list
     notes: list
     current_md: str
-    current_semconv: SemanticConvention
 
     def __init__(self, break_count):
         self.is_full = False
@@ -189,13 +187,16 @@ class MarkdownRenderer:
             counter += 1
 
     def to_markdown_unit_table(self, members, output):
-        output.write('\n')
+        output.write("\n")
         output.write(
-            '| Name        | Kind of Quantity         | Unit String   |\n'
-            '| ------------| ----------------         | -----------   |')
+            "| Name        | Kind of Quantity         | Unit String   |\n"
+            "| ------------| ----------------         | -----------   |"
+        )
         for member in members.values():
-            output.write('\n| {} | {} | `{}` |'.format(member.id, member.brief, member.value))
-        output.write('\n')
+            output.write(
+                "\n| {} | {} | `{}` |".format(member.id, member.brief, member.value)
+            )
+        output.write("\n")
 
     def to_markdown_enum(self, output: io.StringIO):
         """ Renders enum types after a Semantic Convention Table
@@ -368,9 +369,7 @@ class MarkdownRenderer:
             last_match = end_match.end()
         output.write(content[last_match:])
 
-    def _render_table(
-        self, semconv: SemanticConvention, parameters, output: io.StringIO
-    ):
+    def _render_table(self, semconv, parameters, output):
         header: str
         header = semconv.semconv_id
         if parameters:
@@ -405,7 +404,7 @@ class MarkdownRenderer:
             for cnst in semconv.constraints:
                 self.to_markdown_constraint(cnst, output)
         self.to_markdown_enum(output)
-        
+
         if isinstance(semconv, UnitSemanticConvention):
             self.to_markdown_unit_table(semconv.members, output)
 

--- a/semantic-conventions/src/tests/conftest.py
+++ b/semantic-conventions/src/tests/conftest.py
@@ -9,16 +9,16 @@ _TEST_DIR = os.path.dirname(__file__)
 
 @pytest.fixture
 def test_file_path():
-    def loader(filename):
-        return os.path.join(_TEST_DIR, "data", filename)
+    def loader(*path):
+        return os.path.join(_TEST_DIR, "data", *path)
 
     return loader
 
 
 @pytest.fixture
 def open_test_file(test_file_path):
-    def loader(filename):
-        return open(test_file_path(filename), "r", encoding="utf-8")
+    def loader(*path):
+        return open(test_file_path(*path), "r", encoding="utf-8")
 
     return loader
 
@@ -30,3 +30,12 @@ def load_yaml(open_test_file):
             return YAML().load(yaml_file)
 
     return loader
+
+
+@pytest.fixture
+def read_test_file(open_test_file):
+    def reader(*path):
+        with open_test_file(*path) as test_file:
+            return test_file.read()
+
+    return reader

--- a/semantic-conventions/src/tests/data/jinja/metrics/expected.java
+++ b/semantic-conventions/src/tests/data/jinja/metrics/expected.java
@@ -1,0 +1,23 @@
+package io.opentelemetry.instrumentation.api.metric;
+
+class Units {
+
+    /**
+    * Use this unit for Metric Instruments recording values
+    * representing fraction of a total.
+    **/
+    public static final String PERCENT = "%";
+
+    /**
+    * Use this unit for Metric Instruments recording values
+    * representing time.
+    **/
+    public static final String NANOSECOND = "NS";
+
+    /**
+    * Use this unit for Metric Instruments recording values
+    * representing connections.
+    **/
+    public static final String CONNECTIONS = "{connections}";
+
+}

--- a/semantic-conventions/src/tests/data/jinja/metrics/units_template
+++ b/semantic-conventions/src/tests/data/jinja/metrics/units_template
@@ -1,0 +1,11 @@
+package io.opentelemetry.instrumentation.api.metric;
+
+class Units {
+{% for member in semconvs['units'].members.values() %}{% set constant_name = member.id.upper() %}
+    /**
+    * Use this unit for Metric Instruments recording values
+    * representing {{member.brief}}.
+    **/
+    public static final String {{constant_name}} = "{{member.value}}";
+{% endfor %}
+}

--- a/semantic-conventions/src/tests/data/markdown/metrics/units_input.md
+++ b/semantic-conventions/src/tests/data/markdown/metrics/units_input.md
@@ -1,0 +1,4 @@
+# Units
+
+<!-- semconv units -->
+<!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/markdown/metrics/units_output.md
+++ b/semantic-conventions/src/tests/data/markdown/metrics/units_output.md
@@ -1,0 +1,10 @@
+# Units
+
+<!-- semconv units -->
+
+| Name        | Kind of Quantity         | Unit String   |
+| ------------| ----------------         | -----------   |
+| percent | fraction of a total | `%` |
+| nanosecond | time | `NS` |
+| connections | connections | `{connections}` |
+<!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/yaml/metrics/units.yaml
+++ b/semantic-conventions/src/tests/data/yaml/metrics/units.yaml
@@ -1,0 +1,14 @@
+groups:
+  - id: units
+    type: units 
+    brief: Specification of commonly used units.
+    members:
+    - id: percent
+      brief: fraction of a total
+      value: "%"
+    - id: nanosecond
+      brief: time
+      value: NS
+    - id: connections
+      brief: connections
+      value: "{connections}"

--- a/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
+++ b/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
@@ -18,7 +18,7 @@ import unittest
 from opentelemetry.semconv.model.constraints import Include
 from opentelemetry.semconv.model.semantic_attribute import SemanticAttribute
 from opentelemetry.semconv.model.semantic_convention import (
-    SemanticConvention,
+    parse_semantic_convention_groups,
     SemanticConventionSet,
 )
 
@@ -544,7 +544,7 @@ class TestCorrectParse(unittest.TestCase):
         self.assertEqual(attrs[7].inherited, False)
         self.assertEqual(attrs[7].ref, None)
 
-    def semantic_convention_check(self, s: SemanticConvention, expected: dict):
+    def semantic_convention_check(self, s, expected):
         self.assertEqual(expected["prefix"], s.prefix)
         self.assertEqual(expected["extends"], s.extends)
         self.assertEqual(expected["id"], s.semconv_id)

--- a/semantic-conventions/src/tests/semconv/model/test_error_detection.py
+++ b/semantic-conventions/src/tests/semconv/model/test_error_detection.py
@@ -48,7 +48,7 @@ class TestCorrectErrorDetection(unittest.TestCase):
             self.fail()
         e = ex.exception
         msg = e.message.lower()
-        self.assertIn("resources cannot have span_kind", msg)
+        self.assertIn("invalid keys: ['span_kind']", msg)
         self.assertEqual(e.line, 4)
 
     def test_invalid_id(self):

--- a/semantic-conventions/src/tests/semconv/model/test_error_detection.py
+++ b/semantic-conventions/src/tests/semconv/model/test_error_detection.py
@@ -17,7 +17,7 @@ import unittest
 
 from opentelemetry.semconv.model.exceptions import ValidationError
 from opentelemetry.semconv.model.semantic_convention import (
-    SemanticConvention,
+    parse_semantic_convention_groups,
     SemanticConventionSet,
 )
 
@@ -360,7 +360,7 @@ class TestCorrectErrorDetection(unittest.TestCase):
 
     def open_yaml(self, path):
         with open(self.load_file(path), encoding="utf-8") as file:
-            return SemanticConvention.parse(file)
+            return parse_semantic_convention_groups(file)
 
     _TEST_DIR = os.path.dirname(__file__)
 

--- a/semantic-conventions/src/tests/semconv/model/test_semantic_convention.py
+++ b/semantic-conventions/src/tests/semconv/model/test_semantic_convention.py
@@ -13,12 +13,15 @@
 #   limitations under the License.
 
 import os
-from opentelemetry.semconv.model.semantic_convention import SemanticConvention, SpanKind
+from opentelemetry.semconv.model.semantic_convention import (
+    parse_semantic_convention_groups,
+    SpanKind,
+)
 
 
 def test_parse_basic(open_test_file):
     with open_test_file(os.path.join("yaml", "basic_example.yml")) as yaml_file:
-        conventions = SemanticConvention.parse(yaml_file)
+        conventions = parse_semantic_convention_groups(yaml_file)
 
     assert conventions is not None
     assert len(conventions) == 2

--- a/semantic-conventions/src/tests/semconv/model/test_semantic_convention_units.py
+++ b/semantic-conventions/src/tests/semconv/model/test_semantic_convention_units.py
@@ -1,0 +1,34 @@
+import os
+from opentelemetry.semconv.model.semantic_convention import (
+    SemanticConvention,
+    UnitSemanticConvention,
+)
+
+
+def test_build_units(open_test_file):
+    with open_test_file(os.path.join("yaml", "metrics", "units.yaml")) as yaml_file:
+        conventions = SemanticConvention.parse(yaml_file)
+
+    assert len(conventions) == 1
+    convention = conventions[0]
+
+    assert isinstance(convention, UnitSemanticConvention)
+    assert convention.id == "units"
+    assert convention.brief == "Specification of commonly used units."
+
+    assert len(convention.members) == 3
+    assert sorted(convention.members) == sorted(
+        ["percent", "nanosecond", "connections"]
+    )
+
+    assert convention.members["percent"].id == "percent"
+    assert convention.members["percent"].brief == "fraction of a total"
+    assert convention.members["percent"].value == "%"
+
+    assert convention.members["nanosecond"].id == "nanosecond"
+    assert convention.members["nanosecond"].brief == "time"
+    assert convention.members["nanosecond"].value == "NS"
+
+    assert convention.members["connections"].id == "connections"
+    assert convention.members["connections"].brief == "connections"
+    assert convention.members["connections"].value == "{connections}"

--- a/semantic-conventions/src/tests/semconv/model/test_semantic_convention_units.py
+++ b/semantic-conventions/src/tests/semconv/model/test_semantic_convention_units.py
@@ -1,13 +1,13 @@
 import os
 from opentelemetry.semconv.model.semantic_convention import (
-    SemanticConvention,
+    parse_semantic_convention_groups,
     UnitSemanticConvention,
 )
 
 
 def test_build_units(open_test_file):
     with open_test_file(os.path.join("yaml", "metrics", "units.yaml")) as yaml_file:
-        conventions = SemanticConvention.parse(yaml_file)
+        conventions = parse_semantic_convention_groups(yaml_file)
 
     assert len(conventions) == 1
     convention = conventions[0]

--- a/semantic-conventions/src/tests/semconv/templating/test_code.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_code.py
@@ -1,0 +1,23 @@
+import io
+import tempfile
+import os
+
+from opentelemetry.semconv.model.semantic_convention import SemanticConventionSet
+from opentelemetry.semconv.templating.code import CodeRenderer
+
+
+def test_codegen_units(test_file_path, read_test_file):
+    semconv = SemanticConventionSet(debug=False)
+    semconv.parse(test_file_path("yaml", "metrics", "units.yaml"))
+    semconv.finish()
+
+    template_path = test_file_path("jinja", "metrics", "units_template")
+    renderer = CodeRenderer({})
+
+    output = io.StringIO()
+    renderer.render(semconv, template_path, output, None)
+    result = output.getvalue()
+
+    expected = read_test_file("jinja", "metrics", "expected.java")
+
+    assert result == expected


### PR DESCRIPTION
This PR adds a new semantic convention type: units. 
There will only be the one table of units in the spec, but because we're expecting every language to create common constants for metric instrument units (see: [#1177](https://github.com/open-telemetry/opentelemetry-specification/pull/1177), I'd like to make it as easy as possible to generate the constants in code.

The unit yaml looks something like this:
```yaml
groups:
  - id: units
    type: units 
    brief: Specification of commonly used units.
    members:
    - id: percent
      brief: fraction of a total
      value: "%"
    - id: nanosecond
      brief: time
      value: NS
    - id: connections
      brief: connections
      value: "{connections}"
```

And the resulting markdown looks like this:

| Name        | Kind of Quantity         | Unit String   |
| ------------| ----------------         | -----------   |
| percent | fraction of a total | `%` |
| nanosecond | time | `NS` |
| connections | connections | `{connections}` |

There are a few concepts to check out:
* I've created four new classes to define out (currently four) semantic convention types (span, resource, metric, unit). These classes share yaml validation logic, but they each define their own allowed/required keys. The SemanticConvention base class acts as a factory for the four subclasses.
* I removed the `@dataclass` annotation from SemanticConvention, and added a custom constructor that takes a single yaml node as an argument. 

I've added tests for the new functionality, and I've manually run the markdown generator against the opentelemetry-specification repo, and it doesn't have any side-effects. 