### PR TITLE
Fix markdown generator for int enums and add test

### DIFF
--- a/semantic-conventions/CHANGELOG.md
+++ b/semantic-conventions/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
-Please update changelog as part of any significant pull request. 
+Please update the changelog as part of any significant pull request.
 
-# v0.3.0
+## v0.3.1
 
-- BREAKING CHANGE: Removed `number` and `number[]` attribute types in favor of `int`, `int[]`, `double` and `double[]`. (#30) 
+- Fix markdown generator for int enums. (#36)
+
+## v0.3.0
+
+- BREAKING CHANGE: Removed `number` and `number[]` attribute types in favor of `int`, `int[]`, `double` and `double[]`. (#30)

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
@@ -360,7 +360,7 @@ class EnumAttributeType:
         return self.enum_type
 
     @staticmethod
-    def __is_valid_enum_value__(val):
+    def is_valid_enum_value(val):
         return isinstance(val, int) or isinstance(val, str)
 
     @staticmethod
@@ -394,7 +394,7 @@ class EnumAttributeType:
             mandatory_keys = ["id", "value"]
             for member in attribute_type["members"]:
                 validate_values(member, allowed_keys, mandatory_keys)
-                if not EnumAttributeType.__is_valid_enum_value__(member["value"]):
+                if not EnumAttributeType.is_valid_enum_value(member["value"]):
                     raise ValidationError(0, 0, "Invalid value used in enum: <{}>".format(member["value"]))
                 members.append(
                     EnumMember(

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
@@ -361,7 +361,7 @@ class EnumAttributeType:
 
     @staticmethod
     def is_valid_enum_value(val):
-        return isinstance(val, int) or isinstance(val, str)
+        return isinstance(val, (int, str))
 
     @staticmethod
     def parse(attribute_type):

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
@@ -271,8 +271,12 @@ class AttributeType:
 
     @staticmethod
     def get_type(t):
-        if isinstance(t, numbers.Number):
+        if isinstance(t, int):
             return "int"
+        if isinstance(t, numbers.Number):
+            raise ValidationError(
+                0, 0, "Invalid value used in enum - only integers are allowed for numeric values"
+            )
         if AttributeType.bool_type.fullmatch(t):
             return "boolean"
         return "string"

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
@@ -273,10 +273,6 @@ class AttributeType:
     def get_type(t):
         if isinstance(t, int):
             return "int"
-        if isinstance(t, numbers.Number):
-            raise ValidationError(
-                0, 0, "Invalid value used in enum - only integers are allowed for numeric values"
-            )
         if AttributeType.bool_type.fullmatch(t):
             return "boolean"
         return "string"
@@ -364,6 +360,10 @@ class EnumAttributeType:
         return self.enum_type
 
     @staticmethod
+    def __is_valid_enum_value__(val):
+        return isinstance(val, int) or isinstance(val, str)
+
+    @staticmethod
     def parse(attribute_type):
         """ This method parses the yaml representation for semantic attribute types.
             If the type is an enumeration, it generated the EnumAttributeType object,
@@ -394,6 +394,8 @@ class EnumAttributeType:
             mandatory_keys = ["id", "value"]
             for member in attribute_type["members"]:
                 validate_values(member, allowed_keys, mandatory_keys)
+                if not EnumAttributeType.__is_valid_enum_value__(member["value"]):
+                    raise ValidationError(0, 0, "Invalid value used in enum: <{}>".format(member["value"]))
                 members.append(
                     EnumMember(
                         member_id=member["id"],

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
@@ -272,7 +272,7 @@ class AttributeType:
     @staticmethod
     def get_type(t):
         if isinstance(t, numbers.Number):
-            return "number"
+            return "int"
         if AttributeType.bool_type.fullmatch(t):
             return "boolean"
         return "string"

--- a/semantic-conventions/src/opentelemetry/semconv/version.py
+++ b/semantic-conventions/src/opentelemetry/semconv/version.py
@@ -12,4 +12,4 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/semantic-conventions/src/tests/data/markdown/enum_int/expected.md
+++ b/semantic-conventions/src/tests/data/markdown/enum_int/expected.md
@@ -1,0 +1,29 @@
+# RPC.GRPC with int enum
+
+<!-- semconv rpc.grpc -->
+| Attribute  | Type | Description  | Examples  | Required |
+|---|---|---|---|---|
+| `rpc.grpc.status_code` | int | The [numeric status code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC request. | `0`; `1`; `16` | Yes |
+
+`rpc.grpc.status_code` MUST be one of the following:
+
+| Value  | Description |
+|---|---|
+| `0` | OK |
+| `1` | CANCELLED |
+| `2` | UNKNOWN |
+| `3` | INVALID_ARGUMENT |
+| `4` | DEADLINE_EXCEEDED |
+| `5` | NOT_FOUND |
+| `6` | ALREADY_EXISTS |
+| `7` | PERMISSION_DENIED |
+| `8` | RESOURCE_EXHAUSTED |
+| `9` | FAILED_PRECONDITION |
+| `10` | ABORTED |
+| `11` | OUT_OF_RANGE |
+| `12` | UNIMPLEMENTED |
+| `13` | INTERNAL |
+| `14` | UNAVAILABLE |
+| `15` | DATA_LOSS |
+| `16` | UNAUTHENTICATED |
+<!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/markdown/enum_int/input.md
+++ b/semantic-conventions/src/tests/data/markdown/enum_int/input.md
@@ -1,0 +1,5 @@
+# RPC.GRPC with int enum
+
+<!-- semconv rpc.grpc -->
+table will be generated here
+<!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/markdown/enum_int/rpc.yaml
+++ b/semantic-conventions/src/tests/data/markdown/enum_int/rpc.yaml
@@ -1,0 +1,46 @@
+groups:
+    - id: rpc.grpc
+      prefix: rpc.grpc
+      # extends: rpc -- we only care about the int enum here
+      brief: 'Tech-specific attributes for gRPC.'
+      attributes:
+        - id: status_code
+          type:
+            members:
+              - id: OK
+                value: 0
+              - id: CANCELLED
+                value: 1
+              - id: UNKNOWN
+                value: 2
+              - id: INVALID_ARGUMENT
+                value: 3
+              - id: DEADLINE_EXCEEDED
+                value: 4
+              - id: NOT_FOUND
+                value: 5
+              - id: ALREADY_EXISTS
+                value: 6
+              - id: PERMISSION_DENIED
+                value: 7
+              - id: RESOURCE_EXHAUSTED
+                value: 8
+              - id: FAILED_PRECONDITION
+                value: 9
+              - id: ABORTED
+                value: 10
+              - id: OUT_OF_RANGE
+                value: 11
+              - id: UNIMPLEMENTED
+                value: 12
+              - id: INTERNAL
+                value: 13
+              - id: UNAVAILABLE
+                value: 14
+              - id: DATA_LOSS
+                value: 15
+              - id: UNAUTHENTICATED
+                value: 16
+          required: always
+          brief: "The [numeric status code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC request."
+          examples: [0, 1, 16]

--- a/semantic-conventions/src/tests/data/yaml/errors/enum/enum_with_double_values.yaml
+++ b/semantic-conventions/src/tests/data/yaml/errors/enum/enum_with_double_values.yaml
@@ -1,0 +1,16 @@
+groups:
+    - id: rpc.grpc
+      prefix: rpc.grpc
+      # extends: rpc -- we only care about the DOUBLE enum here
+      brief: 'Tech-specific attributes for gRPC.'
+      attributes:
+        - id: status_code
+          type:
+            members:
+              - id: OK
+                value: 0.0
+              - id: CANCELLED
+                value: 1.0
+          required: always
+          brief: "The [numeric status code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC request."
+          examples: [0.0, 1.0]

--- a/semantic-conventions/src/tests/semconv/model/test_error_detection.py
+++ b/semantic-conventions/src/tests/semconv/model/test_error_detection.py
@@ -254,7 +254,6 @@ class TestCorrectErrorDetection(unittest.TestCase):
         e = ex.exception
         msg = e.message.lower()
         self.assertIn("invalid value used in enum", msg)
-        self.assertIn("only integers are allowed for numeric values", msg)
         self.assertEqual(e.line, 8)
 
     def test_examples_wrong_type(self):

--- a/semantic-conventions/src/tests/semconv/model/test_error_detection.py
+++ b/semantic-conventions/src/tests/semconv/model/test_error_detection.py
@@ -247,6 +247,16 @@ class TestCorrectErrorDetection(unittest.TestCase):
         self.assertIn("type", msg)
         self.assertEqual(e.line, 9)
 
+    def test_enum_with_double_values(self):
+        with self.assertRaises(ValidationError) as ex:
+            self.open_yaml("yaml/errors/enum/enum_with_double_values.yaml")
+            self.fail()
+        e = ex.exception
+        msg = e.message.lower()
+        self.assertIn("invalid value used in enum", msg)
+        self.assertIn("only integers are allowed for numeric values", msg)
+        self.assertEqual(e.line, 8)
+
     def test_examples_wrong_type(self):
         with self.assertRaises(ValidationError) as ex:
             self.open_yaml("yaml/errors/examples/example.types.yaml")

--- a/semantic-conventions/src/tests/semconv/templating/test_markdown.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_markdown.py
@@ -137,6 +137,23 @@ class TestCorrectMarkdown(unittest.TestCase):
             expected,
         )
 
+    def testEnumInt(self):
+        semconv = SemanticConventionSet(debug=False)
+        semconv.parse(self.load_file("markdown/enum_int/rpc.yaml"))
+        semconv.finish()
+        self.assertEqual(len(semconv.models), 1)
+        with open(self.load_file("markdown/enum_int/input.md"), "r") as markdown:
+            content = markdown.read()
+        with open(self.load_file("markdown/enum_int/expected.md"), "r") as markdown:
+            expected = markdown.read()
+        self.check_render(
+            semconv,
+            "markdown/enum_int/",
+            "markdown/enum_int/input.md",
+            content,
+            expected,
+        )
+
     def testExtendConstraint(self):
         semconv = SemanticConventionSet(debug=False)
         semconv.parse(self.load_file("markdown/extend_constraint/database.yaml"))


### PR DESCRIPTION
I just noticed that it still says `number` here:
https://github.com/open-telemetry/opentelemetry-specification/blob/b67faa4e0106cac194a837e3d419ae4fab9fc1c4/specification/trace/semantic_conventions/rpc.md#grpc-attributes