### PR TITLE
Fix bug with newlines around enums.

### DIFF
--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
@@ -131,7 +131,6 @@ class SemanticAttribute:
                 validate_id(attr_id, position_data["id"])
                 attr_type, brief, examples = SemanticAttribute.parse_id(attribute)
                 fqn = "{}.{}".format(prefix, attr_id)
-                attr_id = attr_id.strip()
             else:
                 # Ref
                 attr_type = None
@@ -462,10 +461,10 @@ class EnumAttributeType:
                     EnumMember(
                         member_id=member["id"],
                         value=member["value"],
-                        brief=member.get("brief")
+                        brief=member.get("brief").strip()
                         if "brief" in member
                         else member["id"],
-                        note=member.get("note") if "note" in member else "",
+                        note=member.get("note").strip() if "note" in member else "",
                     )
                 )
             enum_type = AttributeType.get_type(members[0].value)

--- a/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
@@ -244,6 +244,8 @@ class MarkdownRenderer:
             for note in notes:
                 output.write("\n\n**[{}]:** {}".format(counter, note))
                 counter += 1
+            if notes:
+                output.write("\n")
 
     def render_attribute_id(self, attribute_id):
         """

--- a/semantic-conventions/src/opentelemetry/semconv/version.py
+++ b/semantic-conventions/src/opentelemetry/semconv/version.py
@@ -12,4 +12,4 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/semantic-conventions/src/tests/data/markdown/multiple_enum/expected.md
+++ b/semantic-conventions/src/tests/data/markdown/multiple_enum/expected.md
@@ -36,11 +36,12 @@
 
 | Value  | Description |
 |---|---|
-| `wifi` | wifi |
+| `wifi` | wifi [1] |
 | `wired` | wired |
 | `cell` | cell |
 | `unavailable` | unavailable |
 
+**[1]:** Usually 802.11
 `net.host.connection.subtype` MUST be one of the following or, if none of the listed values apply, a custom value:
 
 | Value  | Description |

--- a/semantic-conventions/src/tests/data/markdown/multiple_enum/expected.md
+++ b/semantic-conventions/src/tests/data/markdown/multiple_enum/expected.md
@@ -42,18 +42,14 @@
 | `unavailable` | unavailable |
 
 **[1]:** Usually 802.11
+
 `net.host.connection.subtype` MUST be one of the following or, if none of the listed values apply, a custom value:
 
 | Value  | Description |
 |---|---|
-| `1G` | 1G
- |
-| `2G` | 2G
- |
-| `3G` | 3G
- |
-| `4G` | 4G
- |
-| `5G` | 5G
- |
+| `1G` | 1G |
+| `2G` | 2G |
+| `3G` | 3G |
+| `4G` | 4G |
+| `5G` | 5G |
 <!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/markdown/multiple_enum/general.yaml
+++ b/semantic-conventions/src/tests/data/markdown/multiple_enum/general.yaml
@@ -41,6 +41,7 @@ groups:
           members:
             - id: wifi
               value: "wifi"
+              note: "Usually 802.11"
             - id: wired
               value: "wired"
             - id: cell


### PR DESCRIPTION
Turns out #48 merely hid the actual problem which was that the YAML parser adds a trailing newline if you use `>` strings. Probably that is correct, but not what we expect in this context.

In other places we were already using `.strip()`, so also use it here.

This caused some broken formatting internally at Dynatrace where we also use this tool.

This commit also affects the `code` command, not only markdown.