### PR TITLE
Update syntax.md with recent feature additions, document old features

### DIFF
--- a/semantic-conventions/syntax.md
+++ b/semantic-conventions/syntax.md
@@ -162,6 +162,9 @@ An attribute is defined by:
 
   See the [specification of Attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#attributes) for the definition of the value types.
 - `ref`, optional string, reference an existing attribute, see [below](#ref).
+- `tag`, optional string, associates a tag ("sub-group") to the attribute.
+   It carries no particular semantic meaning but can be used e.g. for filtering
+   in the markdown generator.
 - `required`, optional, specifies if the attribute is mandatory.
    Can be "always", or "conditional". When omitted, the attribute is not required.
    When set to "conditional",the string provided as `<condition>` MUST specify

--- a/semantic-conventions/syntax.md
+++ b/semantic-conventions/syntax.md
@@ -67,7 +67,7 @@ span_kind ::= "client"
 
 attributes ::= (id type brief examples | ref [brief] [examples]) [tag] [stability] [deprecated] [required] [sampling_relevant] [note]
 
-# Ref MUST point to an existing ID
+# ref MUST point to an existing attribute id
 ref ::= id
 
 type ::= "string"

--- a/semantic-conventions/syntax.md
+++ b/semantic-conventions/syntax.md
@@ -129,7 +129,7 @@ The field `semconv` represents a semantic convention and it is made by:
    It inherits the prefix, constraints, and all attributes defined in the specified semantic convention.
 - `stability`, optional enum, specifies the stability of the semantic convention.
 
-   Note that, if `stability` is missing but `deprecated` is present, will automatically set the `stability` to `deprecated`.
+   Note that, if `stability` is missing but `deprecated` is present, it will automatically set the `stability` to `deprecated`.
    If `deprecated` is present and `stability` differs from `deprecated`, this will result in an error.
 - `deprecated`, optional, specifies if the semantic convention is deprecated.
    The string provided as `<description>` MUST specify why it's deprecated and/or what to use instead.


### PR DESCRIPTION
This fixes a few issues with syntax.md:

- There was no update to syntax.md for
  * https://github.com/open-telemetry/build-tools/pull/14 which added the "type" field
  * https://github.com/open-telemetry/build-tools/pull/43 which added the "stability" field.
  * This PR does NOT document the units type introduced in https://github.com/open-telemetry/build-tools/pull/21 (because I'm not familiar with it, maybe @justinfoote can create a follow-up).
- The `tag`, `deprecated` and `sampling_relevant` fields that the tool supported from the beginning were never documented.
- The description of `extends` was lacking.

The above was originally written by @thisthat, thank you!

- The relative link to the spec's attributes description broke after moving the tool here.
- Also, some minor formatting improvements & subsection restructuring.
