### PR TITLE
Add support for Event Semantic Conventions

### DIFF
--- a/semantic-conventions/CHANGELOG.md
+++ b/semantic-conventions/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Please update the changelog as part of any significant pull request.
 
+## v0.5.0
+
+- Add event semantic convention type & events span field
+  ([#57](https://github.com/open-telemetry/build-tools/pull/57)).
+
 ## v0.4.0
 
 - Add stability fields. (#35)

--- a/semantic-conventions/semconv.schema.json
+++ b/semantic-conventions/semconv.schema.json
@@ -7,122 +7,154 @@
 		"groups": {
 			"type": "array",
 			"items": {
-				"type": "object",
-				"additionalProperties": false,
-				"required": [
-					"id",
-					"brief"
-				],
 				"anyOf": [
 					{
-						"required": [
-							"attributes"
-						]
+						"allOf": [{"$ref": "#/definitions/SemanticConvention"}]
 					},
 					{
-						"required": [
-							"extends"
-						]
+						"allOf": [{"$ref": "#/definitions/SpanSemanticConvention"}]
 					}
-				],
-				"properties": {
-					"id": {
-						"type": "string",
-						"description": "unique string"
-					},
-					"type": {
-						"type": "string",
-						"enum": [
-							"span",
-							"resource",
-							"metric"
-						]
-					},
-					"brief": {
-						"type": "string",
-						"description": "a brief description of the semantic convention"
-					},
-					"note": {
-						"type": "string",
-						"description": "a more elaborate description of the semantic convention. It defaults to an empty string"
-					},
-					"prefix": {
-						"type": "string",
-						"description": "prefix of the attribute for this semconv. It defaults to an empty string."
-					},
-					"extends": {
-						"type": "string",
-						"description": "reference another semantic convention ID. It inherits all attributes from the specified semconv."
-					},
-					"span_kind": {
-						"type": "string",
-						"enum": [
-							"client",
-							"server",
-							"producer",
-							"consumer",
-							"internal"
-						],
-						"description": "specifies the kind of the span. Leaf semconv nodes (in the hierarchy tree) that do not have this field set will generate a warning."
-					},
-					"attributes": {
-						"type": "array",
-						"items": {
-							"$ref": "#/definitions/Attribute"
-						},
-						"description": "list of attributes that belong to the semconv"
-					},
-					"constraints": {
-						"type": "array",
-						"items": {
-							"anyOf": [
-								{
-									"type": "object",
-									"additionalProperties": false,
-									"required": [
-										"any_of"
-									],
-									"properties": {
-										"any_of": {
-											"type": "array",
-											"description": " accepts a list of sequences. Each sequence contains a list of attribute ids that are required. any_of enforces that all attributes of at least one of the sequences are set.",
-											"items": {
-												"anyOf": [
-													{
-														"type": "array",
-														"items": {
-															"type": "string"
-														}
-													},
-													{
-														"type": "string"
-													}
-												]
-											}
-										}
-									}
-								},
-								{
-									"type": "object",
-									"additionalProperties": false,
-									"required": [
-										"include"
-									],
-									"properties": {
-										"include": {
-											"type": "string",
-											"description": "accepts a semantic conventions id. It includes as part of this semantic convention all constraints and required attributes that are not already defined in the current semantic convention."
-										}
-									}
-								}
-							]
-						}
-					}
-				}
+				]
 			}
 		}
 	},
 	"definitions": {
+		"SemanticConventionBase": {
+			"type": "object",
+			"required": [
+				"id",
+				"brief"
+			],
+			"anyOf": [
+				{
+					"required": [
+						"attributes"
+					]
+				},
+				{
+					"required": [
+						"extends"
+					]
+				}
+			],
+			"properties": {
+				"id": {
+					"type": "string",
+					"description": "unique string"
+				},
+				"type": {
+					"type": "string",
+					"enum": [
+						"span",
+						"resource",
+						"metric",
+						"event"
+					],
+					"description": "The (signal) type of the semantic convention"
+				},
+				"brief": {
+					"type": "string",
+					"description": "a brief description of the semantic convention"
+				},
+				"note": {
+					"type": "string",
+					"description": "a more elaborate description of the semantic convention. It defaults to an empty string"
+				},
+				"prefix": {
+					"type": "string",
+					"description": "prefix of the attribute for this semconv. It defaults to an empty string."
+				},
+				"extends": {
+					"type": "string",
+					"description": "reference another semantic convention ID. It inherits all attributes from the specified semconv."
+				},
+				"attributes": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/Attribute"
+					},
+					"description": "list of attributes that belong to the semconv"
+				},
+				"constraints": {
+					"type": "array",
+					"items": {
+						"anyOf": [
+							{
+								"type": "object",
+								"additionalProperties": false,
+								"required": [
+									"any_of"
+								],
+								"properties": {
+									"any_of": {
+										"type": "array",
+										"description": " accepts a list of sequences. Each sequence contains a list of attribute ids that are required. any_of enforces that all attributes of at least one of the sequences are set.",
+										"items": {
+											"anyOf": [
+												{
+													"type": "array",
+													"items": {
+														"type": "string"
+													}
+												},
+												{
+													"type": "string"
+												}
+											]
+										}
+									}
+								}
+							},
+							{
+								"type": "object",
+								"additionalProperties": false,
+								"required": [
+									"include"
+								],
+								"properties": {
+									"include": {
+										"type": "string",
+										"description": "accepts a semantic conventions id. It includes as part of this semantic convention all constraints and required attributes that are not already defined in the current semantic convention."
+									}
+								}
+							}
+						]
+					}
+				}
+			}
+		},
+		"SpanSemanticConvention": {
+			"allOf": [{ "$ref": "#/definitions/SemanticConventionBase" }],
+			"properties": {
+				"type": {
+					"type": "string",
+					"const": "span"
+				},
+				"span_kind": {
+					"type": "string",
+					"enum": [
+						"client",
+						"server",
+						"producer",
+						"consumer",
+						"internal"
+					],
+					"description": "specifies the kind of the span. Leaf semconv nodes (in the hierarchy tree) that do not have this field set will generate a warning."
+				}
+			}
+		},
+		"SemanticConvention": {
+			"allOf": [{ "$ref": "#/definitions/SemanticConventionBase" }],
+			"required": ["type"],
+			"properties": {
+				"type": {
+					"type": "string",
+					"not": {
+						"const": "span"
+					}
+				}
+			}
+		},
 		"AttributeEnumType": {
 			"type": "object",
 			"additionalProperties": false,

--- a/semantic-conventions/src/opentelemetry/semconv/main.py
+++ b/semantic-conventions/src/opentelemetry/semconv/main.py
@@ -19,7 +19,14 @@ import glob
 import sys
 from typing import List
 
-from opentelemetry.semconv.model.semantic_convention import SemanticConventionSet
+from opentelemetry.semconv.model.semantic_convention import (
+    SemanticConventionSet,
+    SpanSemanticConvention,
+    ResourceSemanticConvention,
+    EventSemanticConvention,
+    MetricSemanticConvention,
+    UnitSemanticConvention,
+)
 from opentelemetry.semconv.templating.code import CodeRenderer
 
 from opentelemetry.semconv.templating.markdown import MarkdownRenderer
@@ -199,7 +206,13 @@ def setup_parser():
     )
     parser.add_argument(
         "--only",
-        choices=["span", "resource", "metric", "units"],
+        choices=[
+            SpanSemanticConvention.GROUP_TYPE_NAME,
+            ResourceSemanticConvention.GROUP_TYPE_NAME,
+            EventSemanticConvention.GROUP_TYPE_NAME,
+            MetricSemanticConvention.GROUP_TYPE_NAME,
+            UnitSemanticConvention.GROUP_TYPE_NAME,
+        ],
         help="Process only semantic conventions of the specified type.",
     )
     parser.add_argument(

--- a/semantic-conventions/src/opentelemetry/semconv/version.py
+++ b/semantic-conventions/src/opentelemetry/semconv/version.py
@@ -12,4 +12,4 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"

--- a/semantic-conventions/src/tests/data/markdown/event/event.yaml
+++ b/semantic-conventions/src/tests/data/markdown/event/event.yaml
@@ -1,0 +1,36 @@
+groups:
+  - id: event
+    type: event
+    prefix: exception
+    brief: >
+      This document defines the attributes used to
+      report a single exception associated with a span.
+    attributes:
+      - id: type
+        type: string
+        brief: >
+          The type of the exception.
+        examples: ["java.net.ConnectException","OSError"]
+      - id: message
+        type: string
+        brief: The exception message.
+        examples: ["Division by zero","Can't convert 'int' object to str implicitly"]
+      - id: stacktrace
+        type: string
+        brief: >
+          A stacktrace.
+        examples: 'Exception in thread "main" java.lang.RuntimeException: Test exception\n
+        at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n
+        at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n
+        at com.example.GenerateTrace.main(GenerateTrace.java:5)'
+      - id: escaped
+        type: boolean
+        brief: >
+          SHOULD be set to true if the exception event is recorded at a point where
+          it is known that the exception is escaping the scope of the span.
+        note: |-
+          An exception is considered to have escaped.
+    constraints:
+      - any_of:
+        - "exception.type"
+        - "exception.message"

--- a/semantic-conventions/src/tests/data/markdown/event/expected.md
+++ b/semantic-conventions/src/tests/data/markdown/event/expected.md
@@ -1,0 +1,17 @@
+# Test
+
+<!-- semconv event -->
+| Attribute  | Type | Description  | Examples  | Required |
+|---|---|---|---|---|
+| `exception.type` | string | The type of the exception. | `java.net.ConnectException`; `OSError` | See below |
+| `exception.message` | string | The exception message. | `Division by zero`; `Can't convert 'int' object to str implicitly` | See below |
+| `exception.stacktrace` | string | A stacktrace. | `Exception in thread "main" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)` | No |
+| `exception.escaped` | boolean | SHOULD be set to true if the exception event is recorded at a point where it is known that the exception is escaping the scope of the span. [1] |  | No |
+
+**[1]:** An exception is considered to have escaped.
+
+**Additional attribute requirements:** At least one of the following sets of attributes is required:
+
+* `exception.type`
+* `exception.message`
+<!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/markdown/event/input.md
+++ b/semantic-conventions/src/tests/data/markdown/event/input.md
@@ -1,0 +1,5 @@
+# Test
+
+<!-- semconv event -->
+
+<!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/yaml/errors/events/missing_event.yaml
+++ b/semantic-conventions/src/tests/data/yaml/errors/events/missing_event.yaml
@@ -16,6 +16,6 @@ groups:
     prefix: random
     brief: example
     attributes:
-        - id: flag
-          type: boolean
-          brief: An attribute.
+      - id: flag
+        type: boolean
+        brief: An attribute.

--- a/semantic-conventions/src/tests/data/yaml/errors/events/missing_event.yaml
+++ b/semantic-conventions/src/tests/data/yaml/errors/events/missing_event.yaml
@@ -1,0 +1,21 @@
+groups:
+  - id: has.events
+    type: span
+    prefix: has.events
+    events:
+      - exception
+      - random.event
+    brief: example
+    attributes:
+      - id: flag
+        type: boolean
+        brief: An attribute.
+
+  - id: random.event
+    type: event
+    prefix: random
+    brief: example
+    attributes:
+        - id: flag
+          type: boolean
+          brief: An attribute.

--- a/semantic-conventions/src/tests/data/yaml/errors/events/no_event_type.yaml
+++ b/semantic-conventions/src/tests/data/yaml/errors/events/no_event_type.yaml
@@ -1,0 +1,20 @@
+groups:
+  - id: has.events
+    type: span
+    prefix: has.events
+    events:
+      - random.event
+    brief: example
+    attributes:
+      - id: flag
+        type: boolean
+        brief: An attribute.
+
+  - id: random.event
+    type: span
+    prefix: random
+    brief: example
+    attributes:
+        - id: flag
+          type: boolean
+          brief: An attribute.

--- a/semantic-conventions/src/tests/data/yaml/errors/events/no_event_type.yaml
+++ b/semantic-conventions/src/tests/data/yaml/errors/events/no_event_type.yaml
@@ -15,6 +15,6 @@ groups:
     prefix: random
     brief: example
     attributes:
-        - id: flag
-          type: boolean
-          brief: An attribute.
+      - id: flag
+        type: boolean
+        brief: An attribute.

--- a/semantic-conventions/src/tests/data/yaml/event.yaml
+++ b/semantic-conventions/src/tests/data/yaml/event.yaml
@@ -1,0 +1,36 @@
+groups:
+  - id: exception
+    type: event
+    prefix: exception
+    brief: >
+      This document defines the attributes used to
+      report a single exception associated with a span.
+    attributes:
+      - id: type
+        type: string
+        brief: >
+          The type of the exception.
+        examples: ["java.net.ConnectException","OSError"]
+      - id: message
+        type: string
+        brief: The exception message.
+        examples: ["Division by zero","Can't convert 'int' object to str implicitly"]
+      - id: stacktrace
+        type: string
+        brief: >
+          A stacktrace.
+        examples: 'Exception in thread "main" java.lang.RuntimeException: Test exception\n
+        at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n
+        at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n
+        at com.example.GenerateTrace.main(GenerateTrace.java:5)'
+      - id: escaped
+        type: boolean
+        brief: >
+          SHOULD be set to true if the exception event is recorded at a point where
+          it is known that the exception is escaping the scope of the span.
+        note: |-
+          An exception is considered to have escaped.
+    constraints:
+      - any_of:
+        - "exception.type"
+        - "exception.message"

--- a/semantic-conventions/src/tests/data/yaml/span_event.yaml
+++ b/semantic-conventions/src/tests/data/yaml/span_event.yaml
@@ -16,6 +16,6 @@ groups:
     prefix: random
     brief: example
     attributes:
-        - id: flag
-          type: boolean
-          brief: An attribute.
+      - id: flag
+        type: boolean
+        brief: An attribute.

--- a/semantic-conventions/src/tests/data/yaml/span_event.yaml
+++ b/semantic-conventions/src/tests/data/yaml/span_event.yaml
@@ -1,0 +1,21 @@
+groups:
+  - id: has.events
+    type: span
+    prefix: has.events
+    events:
+      - exception
+      - random.event
+    brief: example
+    attributes:
+      - id: flag
+        type: boolean
+        brief: An attribute.
+
+  - id: random.event
+    type: event
+    prefix: random
+    brief: example
+    attributes:
+        - id: flag
+          type: boolean
+          brief: An attribute.

--- a/semantic-conventions/src/tests/semconv/model/test_error_detection.py
+++ b/semantic-conventions/src/tests/semconv/model/test_error_detection.py
@@ -407,6 +407,28 @@ class TestCorrectErrorDetection(unittest.TestCase):
         self.assertIn("does not exists", msg)
         self.assertEqual(e.line, 15)
 
+    def test_missing_event(self):
+        with self.assertRaises(ValidationError) as ex:
+            semconv = SemanticConventionSet(debug=False)
+            semconv.parse(self.load_file("yaml/errors/events/missing_event.yaml"))
+            semconv.finish()
+        e = ex.exception
+        msg = e.message.lower()
+        self.assertIn("as event but the latter cannot be found!", msg)
+        self.assertEqual(e.line, 2)
+
+    def test_wrong_event_type(self):
+        with self.assertRaises(ValidationError) as ex:
+            semconv = SemanticConventionSet(debug=False)
+            semconv.parse(self.load_file("yaml/errors/events/no_event_type.yaml"))
+            semconv.finish()
+        e = ex.exception
+        msg = e.message.lower()
+        self.assertIn(
+            "as event but the latter is not a semantic convention for events", msg
+        )
+        self.assertEqual(e.line, 2)
+
     def open_yaml(self, path):
         with open(self.load_file(path), encoding="utf-8") as file:
             return parse_semantic_convention_groups(file)

--- a/semantic-conventions/src/tests/semconv/templating/test_markdown.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_markdown.py
@@ -114,6 +114,9 @@ class TestCorrectMarkdown(unittest.TestCase):
     def test_units(self):
         self.check("markdown/metrics_unit/", extra_yaml_dirs=["yaml/metrics/"])
 
+    def test_event(self):
+        self.check("markdown/event/")
+
     def check(
         self,
         input_dir: str,

--- a/semantic-conventions/syntax.md
+++ b/semantic-conventions/syntax.md
@@ -36,12 +36,13 @@ All attributes are lower case.
 groups ::= semconv
        | semconv groups
 
-semconv ::= id [type] brief [note] [prefix] [extends] [stability] [deprecated] [span_kind] attributes [constraints]
+semconv ::= id [type] brief [note] [prefix] [events] [extends] [stability] [deprecated] [span_kind] attributes [constraints]
 
 id    ::= string
 
 type ::= "span" # Default if not specified
      |   "resource"
+     |   "event"
      |   "metric"
 
 brief ::= string
@@ -49,7 +50,6 @@ note  ::= string
 
 prefix ::= string
 
-# extends MUST point to an existing semconv id
 extends ::= string
 
 stability ::= "deprecated"
@@ -142,6 +142,8 @@ The field `semconv` represents a semantic convention and it is made by:
 The following is only valid if `type` is `span` (the default):
 
 - `span_kind`, optional enum, specifies the kind of the span.
+- `events`, optional list of strings that specify the ids of
+  event semantic conventions associated with this span semantic convention.
 
 ### Attributes
 


### PR DESCRIPTION
Event semantic conventions were designed with span events in mind but should be extendable to log events. See the new tests for how this can be useful to add a YAML definition for the exception semantic conventions in the spec.

This adds two new elements to the YAML definition:
* A new semantic convention type "event", with no additional fields
* A new additional field for "span" semantic conventions to reference associated event semantic conventions.
  The generator validates that the semantic convention exists and the new data is available to the code templates,
  but is not yet used in the markdown output.

It also updates the JSON schema to only allow span_kind and the new events field if the semantic convention type is not specified (defaults to span) or is "span". Unfortunately, we then lose the `"additionalProperties": false`, this seems to be a limitation of the JSON schema language, see https://stackoverflow.com/questions/22689900/json-schema-allof-with-additionalproperties#comment83207554_23001194

Full disclosure: This is the last feature for this tool we had developed internally at Dynatrace before (promise! 😄), so I'm starting off by submitting the status quo here in hopes our code bases back in sync (we already use the event semantic convention type internally).