### PR TITLE
Run & fix linters flake8, pylint, mypy

### DIFF
--- a/.github/workflows/semconvgen.yml
+++ b/.github/workflows/semconvgen.yml
@@ -12,19 +12,28 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    defaults:
+      run: 
+        working-directory: semantic-conventions/
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v2
-    - name: install dependencies
+    - name: install dev-dependencies
       run: |
-        pip install -U pip setuptools wheel
-        pip install -r semantic-conventions/dev-requirements.txt
-    - name: Check formatting
-      run: black --check --diff semantic-conventions/
+        pip install -U pip
+        pip install -U setuptools wheel
+        pip install -r dev-requirements.txt
+    - name: Check formatting (black)
+      run: black --check --diff .
+    - name: Fast basic linting (flake8)
+      run: flake8 .
     - name: install
-      run: pip install -U -e ./semantic-conventions/
+      run: pip install -U -e .
     - name: run tests
       run: pytest -v
+    - name: Slow linting (pylint)
+      run: pylint *.py src/
+      
 
   build-and-publish-docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/semconvgen.yml
+++ b/.github/workflows/semconvgen.yml
@@ -33,6 +33,8 @@ jobs:
       run: pytest -v
     - name: Slow linting (pylint)
       run: pylint *.py src/
+    - name: Type checking (mypy)
+      run: mypy src/
       
 
   build-and-publish-docker:

--- a/semantic-conventions/.flake8
+++ b/semantic-conventions/.flake8
@@ -1,0 +1,15 @@
+# Adapted from https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8
+[flake8]
+extend-ignore = E203
+max-line-length = 120
+exclude =
+  .bzr
+  .git
+  .hg
+  .svn
+  .tox
+  CVS
+  .venv*/
+  venv*/
+  target
+  __pycache__

--- a/semantic-conventions/.pylintrc
+++ b/semantic-conventions/.pylintrc
@@ -1,0 +1,7 @@
+[MESSAGES CONTROL]
+# TODO: We should actually fix the warnings instead of disabling them
+#   except for the stuff up to fixme, which is fine to ignore / defer to black. 
+disable = bad-whitespace, wrong-import-order, wrong-hanging-indentation, line-too-long, missing-docstring, unused-import, fixme, invalid-name, too-many-instance-attributes, too-many-locals, too-many-statements, too-many-branches, too-many-arguments, too-many-public-methods, too-few-public-methods, protected-access
+
+[FORMAT]
+good-names=e,ex

--- a/semantic-conventions/dev-requirements.txt
+++ b/semantic-conventions/dev-requirements.txt
@@ -1,5 +1,5 @@
-black==21.6b0
-pytest==6.1.1
+black==21.8b0
 mypy==0.910
+pytest==6.2.5
 flake8==3.9.2
 pylint==2.10.2

--- a/semantic-conventions/dev-requirements.txt
+++ b/semantic-conventions/dev-requirements.txt
@@ -1,3 +1,4 @@
 black==21.6b0
 mypy==0.770
 pytest==6.1.1
+flake8==3.9.2

--- a/semantic-conventions/dev-requirements.txt
+++ b/semantic-conventions/dev-requirements.txt
@@ -1,5 +1,5 @@
 black==21.6b0
-mypy==0.770
 pytest==6.1.1
+mypy==0.910
 flake8==3.9.2
 pylint==2.10.2

--- a/semantic-conventions/dev-requirements.txt
+++ b/semantic-conventions/dev-requirements.txt
@@ -2,3 +2,4 @@ black==21.6b0
 mypy==0.770
 pytest==6.1.1
 flake8==3.9.2
+pylint==2.10.2

--- a/semantic-conventions/mypy.ini
+++ b/semantic-conventions/mypy.ini
@@ -1,0 +1,7 @@
+[mypy]
+
+[mypy-jinja2.*]
+ignore_missing_imports = True
+
+[mypy-mistune.*]
+ignore_missing_imports = True

--- a/semantic-conventions/setup.py
+++ b/semantic-conventions/setup.py
@@ -8,7 +8,7 @@ VERSION_FILENAME = os.path.join(
 )
 PACKAGE_INFO = {}
 with open(VERSION_FILENAME, encoding="utf-8") as f:
-    exec(f.read(), PACKAGE_INFO)
+    exec(f.read(), PACKAGE_INFO)  # pylint:disable=exec-used
 
 
 VERSION_SUFFIX = os.environ.get("SEMCONGEN_VERSION_SUFFIX")

--- a/semantic-conventions/src/opentelemetry/semconv/main.py
+++ b/semantic-conventions/src/opentelemetry/semconv/main.py
@@ -20,12 +20,8 @@ import sys
 from typing import List
 
 from opentelemetry.semconv.model.semantic_convention import (
+    CONVENTION_CLS_BY_GROUP_TYPE,
     SemanticConventionSet,
-    SpanSemanticConvention,
-    ResourceSemanticConvention,
-    EventSemanticConvention,
-    MetricSemanticConvention,
-    UnitSemanticConvention,
 )
 from opentelemetry.semconv.templating.code import CodeRenderer
 
@@ -206,13 +202,7 @@ def setup_parser():
     )
     parser.add_argument(
         "--only",
-        choices=[
-            SpanSemanticConvention.GROUP_TYPE_NAME,
-            ResourceSemanticConvention.GROUP_TYPE_NAME,
-            EventSemanticConvention.GROUP_TYPE_NAME,
-            MetricSemanticConvention.GROUP_TYPE_NAME,
-            UnitSemanticConvention.GROUP_TYPE_NAME,
-        ],
+        choices=list(CONVENTION_CLS_BY_GROUP_TYPE.keys()),
         help="Process only semantic conventions of the specified type.",
     )
     parser.add_argument(

--- a/semantic-conventions/src/opentelemetry/semconv/model/constraints.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/constraints.py
@@ -39,9 +39,9 @@ class AnyOf:
         _yaml_src_position          Contains the position in the YAML file of the AnyOf attribute
     """
 
-    choice_list_ids: Tuple[Tuple[str, ...]]
+    choice_list_ids: Tuple[Tuple[str, ...], ...]
     inherited: bool = False
-    choice_list_attributes: Tuple[Tuple[SemanticAttribute, ...]] = ()
+    choice_list_attributes: Tuple[Tuple[SemanticAttribute, ...], ...] = ()
     _yaml_src_position: int = 0
 
     def __eq__(self, other):

--- a/semantic-conventions/src/opentelemetry/semconv/model/constraints.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/constraints.py
@@ -12,8 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from dataclasses import dataclass, field, replace
-from typing import List, Tuple, Set
+from dataclasses import dataclass, replace
+from typing import List, Tuple
 
 from opentelemetry.semconv.model.exceptions import ValidationError
 from opentelemetry.semconv.model.semantic_attribute import SemanticAttribute

--- a/semantic-conventions/src/opentelemetry/semconv/model/exceptions.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/exceptions.py
@@ -28,7 +28,7 @@ class ValidationError(Exception):
         return cls(pos[0] + 1, pos[1] + 1, msg)
 
     def __init__(self, line, column, message):
-        super(ValidationError, self).__init__(line, column, message)
+        super().__init__(line, column, message)
         self.message = message
         self.line = line
         self.column = column

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
@@ -82,7 +82,9 @@ class SemanticAttribute:
         return isinstance(self.attr_type, EnumAttributeType)
 
     @staticmethod
-    def parse(prefix, semconv_stability, yaml_attributes) -> "Dict[str, SemanticAttribute]":
+    def parse(
+        prefix, semconv_stability, yaml_attributes
+    ) -> "Dict[str, SemanticAttribute]":
         """This method parses the yaml representation for semantic attributes
         creating the respective SemanticAttribute objects.
         """

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
@@ -16,7 +16,7 @@ import re
 from collections.abc import Iterable
 from dataclasses import dataclass, replace
 from enum import Enum
-from typing import List, Union, Dict
+from typing import List, Optional, Union, Dict
 
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
@@ -88,7 +88,7 @@ class SemanticAttribute:
         """This method parses the yaml representation for semantic attributes
         creating the respective SemanticAttribute objects.
         """
-        attributes = {}
+        attributes = {}  # type: Dict[str, SemanticAttribute]
         allowed_keys = (
             "id",
             "type",
@@ -136,6 +136,7 @@ class SemanticAttribute:
             }
             required_msg = ""
             required_val = attribute.get("required", "")
+            required: Optional[Required]
             if isinstance(required_val, CommentedMap):
                 required = Required.CONDITIONAL
                 required_msg = required_val.get("conditional", None)
@@ -204,7 +205,7 @@ class SemanticAttribute:
                     "Attribute id "
                     + fqn
                     + " is already present at line "
-                    + str(attributes.get(fqn).position[0] + 1)
+                    + str(attributes[fqn].position[0] + 1)
                 )
                 raise ValidationError.from_yaml_pos(position, msg)
             attributes[fqn] = attr

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
@@ -12,7 +12,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import numbers
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass, replace

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -99,6 +99,8 @@ def SemanticConvention(group):
 class BaseSemanticConvention(ValidatableYamlNode):
     """Contains the model extracted from a yaml file"""
 
+    GROUP_TYPE_NAME: str
+
     @property
     def attributes(self):
         if not hasattr(self, "attrs_by_name"):
@@ -541,11 +543,11 @@ class SemanticConventionSet:
 
 CONVENTION_CLS_BY_GROUP_TYPE = {
     cls.GROUP_TYPE_NAME: cls
-    for cls in [
+    for cls in (
         SpanSemanticConvention,
         ResourceSemanticConvention,
         EventSemanticConvention,
         MetricSemanticConvention,
         UnitSemanticConvention,
-    ]
+    )
 }

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -218,9 +218,6 @@ class SpanSemanticConvention(BaseSemanticConvention):
             raise ValidationError.from_yaml_pos(position, msg)
 
 
-print("MRO: ", SpanSemanticConvention.__mro__)
-
-
 class EventSemanticConvention(BaseSemanticConvention):
     GROUP_TYPE_NAME = "event"
 

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -15,7 +15,7 @@
 import sys
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Union, Iterable, Tuple
+from typing import Union
 
 import typing
 from ruamel.yaml import YAML
@@ -25,7 +25,6 @@ from opentelemetry.semconv.model.exceptions import ValidationError
 from opentelemetry.semconv.model.semantic_attribute import (
     HasAttributes,
     SemanticAttribute,
-    StabilityLevel,
     Required,
     unique_attributes,
 )
@@ -463,7 +462,8 @@ class SemanticConventionSet:
                 if not isinstance(event, EventSemanticConvention):
                     raise ValidationError.from_yaml_pos(
                         semconv._position,
-                        "Semantic Convention {} has {} as event but the latter is not a semantic convention for events!".format(
+                        "Semantic Convention {} has {} as event but"
+                        " the latter is not a semantic convention for events!".format(
                             semconv.semconv_id, event_id
                         ),
                     )

--- a/semantic-conventions/src/opentelemetry/semconv/model/utils.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/utils.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 
 import re
+from typing import Tuple
 
 from opentelemetry.semconv.model.exceptions import ValidationError
 
@@ -51,8 +52,8 @@ def check_no_missing_keys(yaml, mandatory):
 
 class ValidatableYamlNode:
 
-    allowed_keys = ()
-    mandatory_keys = ("id", "brief")
+    allowed_keys = ()  # type: Tuple[str, ...]
+    mandatory_keys = ("id", "brief")  # type: Tuple[str, ...]
 
     def __init__(self, yaml_node):
         self.id = yaml_node.get("id").strip()

--- a/semantic-conventions/src/opentelemetry/semconv/templating/code.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/code.py
@@ -63,10 +63,10 @@ def render_markdown(
                 return strong.format(text)
             return super().strong(text) if html else text
 
-        def inline_html(self, html):
+        def inline_html(self, html_text):  # pylint:disable=arguments-renamed
             if inline_html:
-                return inline_html.format(html)
-            return super().inline_html(html) if html else html
+                return inline_html.format(html_text)
+            return super().inline_html(html_text) if html else html_text
 
         def paragraph(self, text):
             if paragraph:

--- a/semantic-conventions/src/opentelemetry/semconv/templating/code.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/code.py
@@ -188,7 +188,9 @@ class CodeRenderer:
         data.update(self.parameters)
         return data
 
-    def get_data_multiple_files(self, semconv, template_path) -> dict:
+    def get_data_multiple_files(
+        self, semconv, template_path
+    ) -> typing.Dict[str, typing.Any]:
         """Returns a dictionary with the data from a single SemanticConvention to fill the template."""
         data = {"template": template_path, "semconv": semconv}
         data.update(self.parameters)

--- a/semantic-conventions/src/opentelemetry/semconv/templating/code.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/code.py
@@ -46,7 +46,7 @@ def render_markdown(
         def link(self, url, text=None, title=None):  # pylint:disable=arguments-renamed
             if link:
                 return link.format(url, text, title)
-            return super().link(url, text, title) if html else link
+            return super().link(url, text, title) if html else url
 
         def image(self, src, alt="", title=None):
             if image:

--- a/semantic-conventions/src/opentelemetry/semconv/templating/code.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/code.py
@@ -38,15 +38,15 @@ def render_markdown(
     heading=None,
     block_code=None,
     block_quote=None,
-    list=None,
+    list=None,  # pylint:disable=redefined-builtin
     list_item=None,
     code=None,
 ):
     class CustomRender(mistune.HTMLRenderer):
-        def link(self, url, text=None, title=None):
+        def link(self, url, text=None, title=None):  # pylint:disable=arguments-renamed
             if link:
                 return link.format(url, text, title)
-            return super().link(url, text, title) if html else url
+            return super().link(url, text, title) if html else link
 
         def image(self, src, alt="", title=None):
             if image:
@@ -63,10 +63,10 @@ def render_markdown(
                 return strong.format(text)
             return super().strong(text) if html else text
 
-        def inline_html(self, html_text):
+        def inline_html(self, html):
             if inline_html:
-                return inline_html.format(html_text)
-            return super().inline_html(html_text) if html else html_text
+                return inline_html.format(html)
+            return super().inline_html(html) if html else html
 
         def paragraph(self, text):
             if paragraph:
@@ -135,12 +135,12 @@ def to_html_links(doc_string: typing.Optional[typing.Union[str, TextWithLinks]])
 
 def regex_replace(text: str, pattern: str, replace: str):
     # convert standard dollar notation to python
-    replace = re.sub(r"\$", r"\\", replace)
+    replace = re.sub(r"\$", r"\\", replace)  # TODO This is *very* surprising behavior
     return re.sub(pattern, replace, text, 0, re.U)
 
 
-def merge(list: typing.List, elm):
-    return list.extend(elm)
+def merge(elems: typing.List, elm):
+    return elems.extend(elm)
 
 
 def to_const_name(name: str) -> str:
@@ -206,10 +206,10 @@ class CodeRenderer:
 
     @staticmethod
     def prefix_output_file(file_name, pattern, semconv):
-        base = os.path.basename(file_name)
-        dir = os.path.dirname(file_name)
+        basename = os.path.basename(file_name)
+        dirname = os.path.dirname(file_name)
         value = getattr(semconv, pattern)
-        return os.path.join(dir, to_camelcase(value, True), base)
+        return os.path.join(dirname, to_camelcase(value, True), basename)
 
     def render(
         self,

--- a/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
@@ -179,7 +179,7 @@ class MarkdownRenderer:
         This method renders anyof constraints into markdown lists
         """
         if anyof.inherited and not self.render_ctx.is_full:
-            return ""
+            return
         output.write(
             "\n**Additional attribute requirements:** At least one of the following sets of attributes is "
             "required:\n\n"
@@ -199,7 +199,8 @@ class MarkdownRenderer:
             output.write("\n**[{}]:** {}\n".format(counter, note))
             counter += 1
 
-    def to_markdown_unit_table(self, members, output):
+    @staticmethod
+    def to_markdown_unit_table(members, output: io.StringIO):
         output.write("\n")
         output.write(
             "| Name        | Kind of Quantity         | Unit String   |\n"
@@ -271,12 +272,10 @@ class MarkdownRenderer:
         """
         if isinstance(obj, AnyOf):
             self.to_markdown_anyof(obj, output)
-            return
-        elif isinstance(obj, Include):
-            return
-        raise Exception(
-            "Trying to generate Markdown for a wrong type {}".format(type(obj))
-        )
+        elif not isinstance(obj, Include):
+            raise Exception(
+                "Trying to generate Markdown for a wrong type {}".format(type(obj))
+            )
 
     def render_md(self):
         for md_filename in self.file_names:

--- a/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
@@ -218,8 +218,7 @@ class MarkdownRenderer:
         """
         attr: SemanticAttribute
         for attr in self.render_ctx.enums:
-            enum: EnumAttributeType
-            enum = attr.attr_type
+            enum = typing.cast(EnumAttributeType, attr.attr_type)
             output.write("\n`" + attr.fqn + "` ")
             if enum.custom_values:
                 output.write(

--- a/semantic-conventions/src/tests/conftest.py
+++ b/semantic-conventions/src/tests/conftest.py
@@ -6,6 +6,9 @@ from ruamel.yaml import YAML
 
 _TEST_DIR = os.path.dirname(__file__)
 
+# Fixtures in pytest work with reused outer names, so shut up pylint here.
+# pylint:disable=redefined-outer-name
+
 
 @pytest.fixture
 def test_file_path():

--- a/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
+++ b/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
@@ -16,10 +16,7 @@ import os
 import unittest
 
 from opentelemetry.semconv.model.constraints import Include, AnyOf
-from opentelemetry.semconv.model.semantic_attribute import (
-    SemanticAttribute,
-    StabilityLevel,
-)
+from opentelemetry.semconv.model.semantic_attribute import StabilityLevel
 from opentelemetry.semconv.model.semantic_convention import (
     SemanticConventionSet,
     SpanSemanticConvention,
@@ -235,12 +232,10 @@ class TestCorrectParse(unittest.TestCase):
         }
         self.semantic_convention_check(event, expected)
         constraint = event.constraints[0]
-        self.assertTrue(isinstance(constraint, AnyOf))
+        self.assertIsInstance(constraint, AnyOf)
         constraint: AnyOf
-        for choice_index in range(len(constraint.choice_list_ids)):
-            attr_list = constraint.choice_list_ids[choice_index]
-            for attr_index in range(len(attr_list)):
-                attr = attr_list[attr_index]
+        for choice_index, attr_list in enumerate(constraint.choice_list_ids):
+            for attr_index, attr in enumerate(attr_list):
                 self.assertEqual(
                     event.attrs_by_name.get(attr),
                     constraint.choice_list_attributes[choice_index][attr_index],
@@ -313,7 +308,6 @@ class TestCorrectParse(unittest.TestCase):
 
         client = list(semconv.models.values())[1]
         server = list(semconv.models.values())[2]
-        attr: SemanticAttribute
         self.assertIsNotNone(client.attributes[1].ref)
         self.assertIsNotNone(client.attributes[1].attr_type)
 
@@ -679,7 +673,3 @@ class TestCorrectParse(unittest.TestCase):
 
     def load_file(self, filename):
         return os.path.join(self._TEST_DIR, "..", "..", "data", filename)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
+++ b/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
@@ -21,7 +21,6 @@ from opentelemetry.semconv.model.semantic_attribute import (
     StabilityLevel,
 )
 from opentelemetry.semconv.model.semantic_convention import (
-    parse_semantic_convention_groups,
     SemanticConventionSet,
     SpanSemanticConvention,
     EventSemanticConvention,

--- a/semantic-conventions/src/tests/semconv/model/test_error_detection.py
+++ b/semantic-conventions/src/tests/semconv/model/test_error_detection.py
@@ -451,7 +451,3 @@ class TestCorrectErrorDetection(unittest.TestCase):
 
     def load_file(self, filename):
         return os.path.join(self._TEST_DIR, "..", "..", "data", filename)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/semantic-conventions/src/tests/semconv/model/test_semantic_convention.py
+++ b/semantic-conventions/src/tests/semconv/model/test_semantic_convention.py
@@ -26,7 +26,7 @@ def test_parse_basic(open_test_file):
     assert conventions is not None
     assert len(conventions) == 2
 
-    first, second = conventions
+    first, second = conventions  # pylint:disable=unbalanced-tuple-unpacking
 
     assert first.semconv_id == "first_group_id"
     assert first.brief == "first description"

--- a/semantic-conventions/src/tests/semconv/model/test_utils.py
+++ b/semantic-conventions/src/tests/semconv/model/test_utils.py
@@ -16,11 +16,8 @@ import pytest
 from opentelemetry.semconv.model.utils import (
     validate_id,
     validate_values,
-    check_no_missing_keys,
 )
 from opentelemetry.semconv.model.exceptions import ValidationError
-
-from ruamel.yaml.comments import CommentedMap
 
 _POSITION = [10, 2]
 

--- a/semantic-conventions/src/tests/semconv/model/test_utils.py
+++ b/semantic-conventions/src/tests/semconv/model/test_utils.py
@@ -23,7 +23,7 @@ _POSITION = [10, 2]
 
 
 @pytest.mark.parametrize(
-    "id",
+    "semconv_id",
     [
         "abc.def",  # all lowercase letters
         "abc.de_fg",  # lowercase letters, plus underscore
@@ -33,18 +33,20 @@ _POSITION = [10, 2]
         "abc.123.ab9.de_fg.hi-jk",
     ],
 )
-def test_validate_id__valid(id):
+def test_validate_id__valid(semconv_id):
     # valid ids are namespaced, dot separated. The topmost name must start with
     # a lowercase letter. The rest of the id may contain only lowercase letters,
     # numbers, underscores, and dashes
 
-    validate_id(id, _POSITION)
+    validate_id(semconv_id, _POSITION)
 
 
-@pytest.mark.parametrize("id", ["123", "ABC", "abc+def", "ab<", "ab^", "abc.de\xfe"])
-def test_validate_id__invalid(id):
+@pytest.mark.parametrize(
+    "semconv_id", ["123", "ABC", "abc+def", "ab<", "ab^", "abc.de\xfe"]
+)
+def test_validate_id__invalid(semconv_id):
     with pytest.raises(ValidationError) as err:
-        validate_id(id, _POSITION)
+        validate_id(semconv_id, _POSITION)
 
     assert err.value.message.startswith("Invalid id")
 

--- a/semantic-conventions/src/tests/semconv/templating/test_code.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_code.py
@@ -1,6 +1,4 @@
 import io
-import tempfile
-import os
 
 from opentelemetry.semconv.model.semantic_convention import SemanticConventionSet
 from opentelemetry.semconv.templating.code import CodeRenderer

--- a/semantic-conventions/src/tests/semconv/templating/test_markdown.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_markdown.py
@@ -159,6 +159,7 @@ class TestCorrectMarkdown(unittest.TestCase):
         do_render()
         result = output.getvalue()
         assert result == (dirpath / expected_name).read_text(encoding="utf-8")
+        return None
 
     _TEST_DIR = os.path.dirname(__file__)
 


### PR DESCRIPTION
This fixes errors from & runs the following linters, that are all also used in opentelemetry-python:

- flake8 (a fast & simple linter)
- pylint (a slow linter that does some code analysis)
- mypy (a checker for the type annotations we already had in place)