### PR TITLE
Add isort to ensure consistent ordering of imports.

### DIFF
--- a/.github/workflows/semconvgen.yml
+++ b/.github/workflows/semconvgen.yml
@@ -29,6 +29,8 @@ jobs:
       run: flake8 .
     - name: install
       run: pip install -U -e .
+    - name: Check imports (isort)
+      run: isort --check --diff .
     - name: run tests
       run: pytest -v
     - name: Slow linting (pylint)

--- a/semantic-conventions/dev-requirements.txt
+++ b/semantic-conventions/dev-requirements.txt
@@ -3,3 +3,4 @@ mypy==0.910
 pytest==6.2.5
 flake8==3.9.2
 pylint==2.10.2
+isort==5.9.3

--- a/semantic-conventions/setup.cfg
+++ b/semantic-conventions/setup.cfg
@@ -29,3 +29,6 @@ where = src
 [options.entry_points]
 console_scripts =
     gen-semconv = opentelemetry.semconv.main:main
+
+[isort]
+profile = black

--- a/semantic-conventions/src/opentelemetry/semconv/main.py
+++ b/semantic-conventions/src/opentelemetry/semconv/main.py
@@ -24,7 +24,6 @@ from opentelemetry.semconv.model.semantic_convention import (
     SemanticConventionSet,
 )
 from opentelemetry.semconv.templating.code import CodeRenderer
-
 from opentelemetry.semconv.templating.markdown import MarkdownRenderer
 from opentelemetry.semconv.templating.markdown.options import MarkdownOptions
 

--- a/semantic-conventions/src/opentelemetry/semconv/model/constraints.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/constraints.py
@@ -15,11 +15,11 @@
 from dataclasses import dataclass, replace
 from typing import List, Tuple
 
+from ruamel.yaml.comments import CommentedSeq
+
 from opentelemetry.semconv.model.exceptions import ValidationError
 from opentelemetry.semconv.model.semantic_attribute import SemanticAttribute
 from opentelemetry.semconv.model.utils import validate_values
-
-from ruamel.yaml.comments import CommentedSeq
 
 
 # We cannot frozen due to later evaluation of the attributes

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
@@ -16,15 +16,15 @@ import re
 from collections.abc import Iterable
 from dataclasses import dataclass, replace
 from enum import Enum
-from typing import List, Optional, Union, Dict
+from typing import Dict, List, Optional, Union
 
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
 from opentelemetry.semconv.model.exceptions import ValidationError
 from opentelemetry.semconv.model.utils import (
-    validate_values,
-    validate_id,
     check_no_missing_keys,
+    validate_id,
+    validate_values,
 )
 
 

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -13,25 +13,22 @@
 #   limitations under the License.
 
 import sys
+import typing
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Union
 
-import typing
 from ruamel.yaml import YAML
 
-from opentelemetry.semconv.model.constraints import Include, AnyOf, parse_constraints
+from opentelemetry.semconv.model.constraints import AnyOf, Include, parse_constraints
 from opentelemetry.semconv.model.exceptions import ValidationError
 from opentelemetry.semconv.model.semantic_attribute import (
-    SemanticAttribute,
     Required,
+    SemanticAttribute,
     unique_attributes,
 )
 from opentelemetry.semconv.model.unit_member import UnitMember
-from opentelemetry.semconv.model.utils import (
-    ValidatableYamlNode,
-    validate_id,
-)
+from opentelemetry.semconv.model.utils import ValidatableYamlNode, validate_id
 
 
 class SpanKind(Enum):

--- a/semantic-conventions/src/opentelemetry/semconv/model/utils.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/utils.py
@@ -17,7 +17,6 @@ from typing import Tuple
 
 from opentelemetry.semconv.model.exceptions import ValidationError
 
-
 ID_RE = re.compile("([a-z](\\.?[a-z0-9_-]+)+)")
 
 

--- a/semantic-conventions/src/opentelemetry/semconv/templating/code.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/code.py
@@ -16,14 +16,13 @@ import datetime
 import os.path
 import re
 import typing
-import mistune
 
+import mistune
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
-from opentelemetry.semconv.model.semantic_attribute import TextWithLinks
+from opentelemetry.semconv.model.semantic_attribute import Required, TextWithLinks
 from opentelemetry.semconv.model.semantic_convention import SemanticConventionSet
 from opentelemetry.semconv.model.utils import ID_RE
-from opentelemetry.semconv.model.semantic_attribute import Required
 
 
 def render_markdown(

--- a/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
@@ -22,18 +22,17 @@ from pathlib import PurePath
 
 from opentelemetry.semconv.model.constraints import AnyOf, Include
 from opentelemetry.semconv.model.semantic_attribute import (
+    EnumAttributeType,
+    EnumMember,
+    Required,
     SemanticAttribute,
     StabilityLevel,
-    EnumAttributeType,
-    Required,
-    EnumMember,
 )
 from opentelemetry.semconv.model.semantic_convention import (
     SemanticConventionSet,
     UnitSemanticConvention,
 )
 from opentelemetry.semconv.model.utils import ID_RE
-
 from opentelemetry.semconv.templating.markdown.options import MarkdownOptions
 
 

--- a/semantic-conventions/src/tests/conftest.py
+++ b/semantic-conventions/src/tests/conftest.py
@@ -1,8 +1,7 @@
 import os
+
 import pytest
-
 from ruamel.yaml import YAML
-
 
 _TEST_DIR = os.path.dirname(__file__)
 

--- a/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
+++ b/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
@@ -15,12 +15,12 @@
 import os
 import unittest
 
-from opentelemetry.semconv.model.constraints import Include, AnyOf
+from opentelemetry.semconv.model.constraints import AnyOf, Include
 from opentelemetry.semconv.model.semantic_attribute import StabilityLevel
 from opentelemetry.semconv.model.semantic_convention import (
+    EventSemanticConvention,
     SemanticConventionSet,
     SpanSemanticConvention,
-    EventSemanticConvention,
 )
 
 

--- a/semantic-conventions/src/tests/semconv/model/test_error_detection.py
+++ b/semantic-conventions/src/tests/semconv/model/test_error_detection.py
@@ -17,8 +17,8 @@ import unittest
 
 from opentelemetry.semconv.model.exceptions import ValidationError
 from opentelemetry.semconv.model.semantic_convention import (
-    parse_semantic_convention_groups,
     SemanticConventionSet,
+    parse_semantic_convention_groups,
 )
 
 

--- a/semantic-conventions/src/tests/semconv/model/test_semantic_convention.py
+++ b/semantic-conventions/src/tests/semconv/model/test_semantic_convention.py
@@ -13,9 +13,10 @@
 #   limitations under the License.
 
 import os
+
 from opentelemetry.semconv.model.semantic_convention import (
-    parse_semantic_convention_groups,
     SpanKind,
+    parse_semantic_convention_groups,
 )
 
 

--- a/semantic-conventions/src/tests/semconv/model/test_semantic_convention_units.py
+++ b/semantic-conventions/src/tests/semconv/model/test_semantic_convention_units.py
@@ -1,7 +1,8 @@
 import os
+
 from opentelemetry.semconv.model.semantic_convention import (
-    parse_semantic_convention_groups,
     UnitSemanticConvention,
+    parse_semantic_convention_groups,
 )
 
 

--- a/semantic-conventions/src/tests/semconv/model/test_utils.py
+++ b/semantic-conventions/src/tests/semconv/model/test_utils.py
@@ -13,11 +13,8 @@
 #   limitations under the License.
 import pytest
 
-from opentelemetry.semconv.model.utils import (
-    validate_id,
-    validate_values,
-)
 from opentelemetry.semconv.model.exceptions import ValidationError
+from opentelemetry.semconv.model.utils import validate_id, validate_values
 
 _POSITION = [10, 2]
 

--- a/semantic-conventions/src/tests/semconv/templating/test_markdown.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_markdown.py
@@ -14,13 +14,13 @@
 
 import io
 import os
-from typing import Optional, Sequence
 import unittest
 from pathlib import Path
+from typing import Optional, Sequence
 
 from opentelemetry.semconv.model.semantic_convention import SemanticConventionSet
-from opentelemetry.semconv.templating.markdown.options import MarkdownOptions
 from opentelemetry.semconv.templating.markdown import MarkdownRenderer
+from opentelemetry.semconv.templating.markdown.options import MarkdownOptions
 
 
 class TestCorrectMarkdown(unittest.TestCase):


### PR DESCRIPTION
This is the last linter, now we have parity with opentelemetry-python.