### PR TITLE
Build multiarch protobuf Docker images

### DIFF
--- a/.github/workflows/protobuf-dockerimage.yml
+++ b/.github/workflows/protobuf-dockerimage.yml
@@ -14,21 +14,37 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Build the Docker image
-      run: docker build protobuf/. -t build-protobuf
-    - name: Push the Docker image
-      if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    - uses: actions/checkout@v2
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_TOKEN }}
+
+    - name: Determine tag
       run: |
-        echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-        function tag_and_push {
-          docker tag build-protobuf "otel/build-protobuf:${1}" && docker push "otel/build-protobuf:${1}"
+        function set_tag {
+          echo "DOCKER_TAG=${1}" >> $GITHUB_ENV
         }
         if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
-          tag_and_push "latest"
+          set_tag "latest"
         elif [[ "${GITHUB_REF}" =~ refs/tags/v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            TAG="${GITHUB_REF#"refs/tags/v"}"
-            tag_and_push "${TAG}"
+          set_tag "${GITHUB_REF#"refs/tags/v"}"
         else
-          tag_and_push "${GITHUB_REF#"refs/tags/"}"
+          set_tag "${GITHUB_REF#"refs/tags/"}"
         fi
+
+    - name: Build and push the Docker image
+      uses: docker/build-push-action@v2
+      with:
+        builder: ${{ steps.buildx.outputs.name }}
+        context: ./protobuf/
+        platforms: linux/amd64,linux/arm64
+        push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+        tags: otel/build-protobuf:${{ env.DOCKER_TAG }}

--- a/.github/workflows/protobuf-dockerimage.yml
+++ b/.github/workflows/protobuf-dockerimage.yml
@@ -25,7 +25,7 @@ jobs:
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_TOKEN }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Determine tag
       run: |

--- a/protobuf/Dockerfile
+++ b/protobuf/Dockerfile
@@ -10,7 +10,7 @@ ARG PROTOC_GEN_GO_GRPC_VERSION=1.36.0
 ARG GRPC_JAVA_VERSION=1.36.0
 # v1.3.2, using the version directly does not work: "tar: invalid magic"
 ARG PROTOC_GEN_GOGO_VERSION=b03c65ea87cdc3521ede29f62fe3ce239267c1bc
-ARG PROTOC_GEN_LINT_VERSION=0.2.1
+ARG PROTOC_GEN_LINT_VERSION=0.2.4
 ARG GRPC_GATEWAY_VERSION=1.16.0
 ARG UPX_VERSION=3.96
 
@@ -102,12 +102,13 @@ RUN mkdir -p ${GOPATH}/src/github.com/gogo/protobuf && \
     install -D ./gogoproto/gogo.proto /out/usr/include/github.com/gogo/protobuf/gogoproto/gogo.proto
 
 ARG PROTOC_GEN_LINT_VERSION
+ARG TARGETARCH
 RUN cd / && \
-    curl -sSLO https://github.com/ckaznocha/protoc-gen-lint/releases/download/v${PROTOC_GEN_LINT_VERSION}/protoc-gen-lint_linux_amd64.zip && \
+    curl -sSLO https://github.com/ckaznocha/protoc-gen-lint/releases/download/v${PROTOC_GEN_LINT_VERSION}/protoc-gen-lint_linux_${TARGETARCH}.zip && \
     mkdir -p /protoc-gen-lint-out && \
     cd /protoc-gen-lint-out && \
-    unzip -q /protoc-gen-lint_linux_amd64.zip && \
-    install -Ds /protoc-gen-lint-out/protoc-gen-lint /out/usr/bin/protoc-gen-lint
+    unzip -q /protoc-gen-lint_linux_${TARGETARCH}.zip && \
+    install -D /protoc-gen-lint-out/protoc-gen-lint /out/usr/bin/protoc-gen-lint
 
 ARG GRPC_GATEWAY_VERSION
 RUN mkdir -p ${GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway && \
@@ -129,7 +130,8 @@ FROM alpine:${ALPINE_VERSION} as packer
 RUN apk add --no-cache curl
 
 ARG UPX_VERSION
-RUN mkdir -p /upx && curl -sSL https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-amd64_linux.tar.xz | tar xJ --strip 1 -C /upx && \
+ARG TARGETARCH
+RUN mkdir -p /upx && curl -sSL https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-${TARGETARCH}_linux.tar.xz | tar xJ --strip 1 -C /upx && \
     install -D /upx/upx /usr/local/bin/upx
 
 # Use all output including headers and protoc from protoc_builder


### PR DESCRIPTION
This adapts `protobuf/Dockerfile` so it can be built for amd64 and arm64 targets by using `TARGETARCH`.
I had to update `PROTOC_GEN_LINT_VERSION` as only [v0.2.4](https://github.com/ckaznocha/protoc-gen-lint/releases) has downloads for all archs.

Next I updated the GitHub Actions workflow, I'm using [docker/build-push-action](https://github.com/docker/build-push-action) to build multiarch images. Under the hood this uses docker buildx.

You can run buildx locally using:
```
docker buildx build --load --platform linux/arm64 -t otel/protobuf:latest protobuf
```

Fixes https://github.com/open-telemetry/build-tools/issues/42