### PR TITLE
make it possible to build the proto compiler using arm64

### DIFF
--- a/protobuf/Dockerfile
+++ b/protobuf/Dockerfile
@@ -4,13 +4,14 @@ ARG GO_VERSION=1.17.1
 ARG GRPC_VERSION=1.36.4
 ARG PROTOBUF_C_VERSION=1.3.3
 ARG GRPC_WEB_VERSION=1.2.1
+ARG ARCH=amd64
 
 ARG PROTOC_GEN_GO_VERSION=1.5.1
 ARG PROTOC_GEN_GO_GRPC_VERSION=1.36.0
 ARG GRPC_JAVA_VERSION=1.36.0
 # v1.3.2, using the version directly does not work: "tar: invalid magic"
 ARG PROTOC_GEN_GOGO_VERSION=b03c65ea87cdc3521ede29f62fe3ce239267c1bc
-ARG PROTOC_GEN_LINT_VERSION=0.2.1
+ARG PROTOC_GEN_LINT_VERSION=0.2.4
 ARG GRPC_GATEWAY_VERSION=1.16.0
 ARG UPX_VERSION=3.96
 
@@ -102,12 +103,13 @@ RUN mkdir -p ${GOPATH}/src/github.com/gogo/protobuf && \
     install -D ./gogoproto/gogo.proto /out/usr/include/github.com/gogo/protobuf/gogoproto/gogo.proto
 
 ARG PROTOC_GEN_LINT_VERSION
+ARG ARCH
 RUN cd / && \
-    curl -sSLO https://github.com/ckaznocha/protoc-gen-lint/releases/download/v${PROTOC_GEN_LINT_VERSION}/protoc-gen-lint_linux_amd64.zip && \
-    mkdir -p /protoc-gen-lint-out && \
-    cd /protoc-gen-lint-out && \
-    unzip -q /protoc-gen-lint_linux_amd64.zip && \
-    install -Ds /protoc-gen-lint-out/protoc-gen-lint /out/usr/bin/protoc-gen-lint
+   curl -sSLO https://github.com/ckaznocha/protoc-gen-lint/releases/download/v${PROTOC_GEN_LINT_VERSION}/protoc-gen-lint_linux_${ARCH}.zip && \
+   mkdir -p /protoc-gen-lint-out && \
+   cd /protoc-gen-lint-out && \
+   unzip -q /protoc-gen-lint_linux_${ARCH}.zip && \
+   install -Ds /protoc-gen-lint-out/protoc-gen-lint /out/usr/bin/protoc-gen-lint
 
 ARG GRPC_GATEWAY_VERSION
 RUN mkdir -p ${GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway && \
@@ -129,7 +131,8 @@ FROM alpine:${ALPINE_VERSION} as packer
 RUN apk add --no-cache curl
 
 ARG UPX_VERSION
-RUN mkdir -p /upx && curl -sSL https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-amd64_linux.tar.xz | tar xJ --strip 1 -C /upx && \
+ARG ARCH
+RUN mkdir -p /upx && curl -sSL https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-${ARCH}_linux.tar.xz | tar xJ --strip 1 -C /upx && \
     install -D /upx/upx /usr/local/bin/upx
 
 # Use all output including headers and protoc from protoc_builder


### PR DESCRIPTION
The default is still to use `amd64` for all builds, but this makes it possible for someone to manually build the proto generator locally. Next step is to add a step to the build to publish a docker container that supports arm64