### PR TITLE
Remove unnecessary USER directive from schema check Dockerfile

### DIFF
--- a/schemas/Dockerfile
+++ b/schemas/Dockerfile
@@ -20,6 +20,4 @@ WORKDIR /
 
 COPY --from=build /schemas-tool /schemas-tool
 
-USER nonroot:nonroot
-
 ENTRYPOINT ["/schemas-tool"]


### PR DESCRIPTION
This was incorrectly added to the Dockerfile and causes problems when running since there is normally no such user on the host machine. This is not necessary, so removing.