### PR TITLE
Update CODEOWNERS for semantic-conventions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,4 +16,4 @@
 *   @open-telemetry/specs-approvers
 
 # Owners for the semantic conventions generator tool
-/semantic-conventions/      @open-telemetry/specs-approvers @thisthat @Oberon00
+/semantic-conventions/      @open-telemetry/specs-approvers @Oberon00


### PR DESCRIPTION
@thisthat is no longer involved in OTel and does not have the capacity to review and build-tools PRs, so let's take him off the list of approvers.

Thank you for your contributions in the past, @thisthat! 😊 