### PR TITLE
Allow customising the `jinja2.Environment`

### DIFF
--- a/semantic-conventions/CHANGELOG.md
+++ b/semantic-conventions/CHANGELOG.md
@@ -4,7 +4,8 @@ Please update the changelog as part of any significant pull request.
 
 ## Unreleased
 
-- Add changes here.
+- Allow customising the `jinja2.Environment` via command line arguments
+  ([#xx](https://github.com/open-telemetry/build-tools/pull/xx)).
 
 ## v0.12.0
 

--- a/semantic-conventions/CHANGELOG.md
+++ b/semantic-conventions/CHANGELOG.md
@@ -4,7 +4,7 @@ Please update the changelog as part of any significant pull request.
 
 ## Unreleased
 
-- Allow customising the `jinja2.Environment` via command line arguments
+- Allow customising whitespace control in Jinja templates
   ([#101](https://github.com/open-telemetry/build-tools/pull/101)).
 
 ## v0.12.0

--- a/semantic-conventions/CHANGELOG.md
+++ b/semantic-conventions/CHANGELOG.md
@@ -5,7 +5,7 @@ Please update the changelog as part of any significant pull request.
 ## Unreleased
 
 - Allow customising the `jinja2.Environment` via command line arguments
-  ([#xx](https://github.com/open-telemetry/build-tools/pull/xx)).
+  ([#101](https://github.com/open-telemetry/build-tools/pull/101)).
 
 ## v0.12.0
 

--- a/semantic-conventions/README.md
+++ b/semantic-conventions/README.md
@@ -124,31 +124,8 @@ This way, multiple files are generated. The value of `pattern` can be one of the
 Finally, additional value can be passed to the template in form of `key=value` pairs separated by
 comma using the `--parameters [{key=value},]+` or `-D` flag.
 
-### Customizing the Jinja Environment
+### Customizing Jinja's Whitespace Control
 
-The image also supports configuring the [Jinja Environment](https://jinja.palletsprojects.com/en/3.0.x/api/#basics)
-via additional values passed in the form of `key=value` pairs separated by comma using the
-`--jinja-env-params [{key=value},]+` or `-J` flag.
-
-> Refer to the Jinja [Environment documentation](https://jinja.palletsprojects.com/en/3.0.x/api/#jinja2.Environment)
-for the complete list of available options. Note that only `string` and `boolean` values are supported at the moment.
-
-Example: Customizing [whitespace control](https://jinja.palletsprojects.com/en/3.1.x/templates/#whitespace-control)
-rendering in templates: 
-
-```bash
-docker run --rm \
-  -v ${SCRIPT_DIR}/opentelemetry-specification/semantic_conventions/trace:/source \
-  -v ${SCRIPT_DIR}/templates:/templates \
-  -v ${ROOT_DIR}/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/:/output \
-  otel/semconvgen:$GENERATOR_VERSION \
-  --yaml-root /source \
-  code \
-  --template /templates/SemanticAttributes.java.j2 \
-  --output /output/SemanticAttributes.java \
-  -Dclass=SemanticAttributes \
-  -DschemaUrl=$SCHEMA_URL \
-  -Dpkg=io.opentelemetry.semconv.trace.attributes
-  -Jtrim_blocks=True \
-  -Jlstrip_blocks=True
-```
+The image also supports customising
+[Whitespace Control in Jinja templates](https://jinja.palletsprojects.com/en/3.1.x/templates/#whitespace-control)
+via the additional flag `--trim-whitespace`. Providing the flag will enable both `lstrip_blocks` and `trim_blocks`.

--- a/semantic-conventions/README.md
+++ b/semantic-conventions/README.md
@@ -123,3 +123,32 @@ This way, multiple files are generated. The value of `pattern` can be one of the
 
 Finally, additional value can be passed to the template in form of `key=value` pairs separated by
 comma using the `--parameters [{key=value},]+` or `-D` flag.
+
+### Customizing the Jinja Environment
+
+The image also supports configuring the [Jinja Environment](https://jinja.palletsprojects.com/en/3.0.x/api/#basics)
+via additional values passed in the form of `key=value` pairs separated by comma using the
+`--jinja-env-params [{key=value},]+` or `-J` flag.
+
+> Refer to the Jinja [Environment documentation](https://jinja.palletsprojects.com/en/3.0.x/api/#jinja2.Environment)
+for the complete list of available options. Note that only `string` and `boolean` values are supported at the moment.
+
+Example: Customizing [whitespace control](https://jinja.palletsprojects.com/en/3.1.x/templates/#whitespace-control)
+rendering in templates: 
+
+```bash
+docker run --rm \
+  -v ${SCRIPT_DIR}/opentelemetry-specification/semantic_conventions/trace:/source \
+  -v ${SCRIPT_DIR}/templates:/templates \
+  -v ${ROOT_DIR}/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/:/output \
+  otel/semconvgen:$GENERATOR_VERSION \
+  --yaml-root /source \
+  code \
+  --template /templates/SemanticAttributes.java.j2 \
+  --output /output/SemanticAttributes.java \
+  -Dclass=SemanticAttributes \
+  -DschemaUrl=$SCHEMA_URL \
+  -Dpkg=io.opentelemetry.semconv.trace.attributes
+  -Jtrim_blocks=True \
+  -Jlstrip_blocks=True
+```

--- a/semantic-conventions/src/opentelemetry/semconv/main.py
+++ b/semantic-conventions/src/opentelemetry/semconv/main.py
@@ -70,7 +70,7 @@ def main():
         parser.error("No semantic convention model found!")
     if args.flavor == "code":
         renderer = CodeRenderer.from_commandline_params(
-            args.parameters, args.jinja_env_params
+            args.parameters, args.trim_whitespace
         )
         renderer.render(semconv, args.template, args.output, args.pattern)
     elif args.flavor == "markdown":
@@ -141,12 +141,11 @@ def add_code_parser(subparsers):
         type=str,
     )
     parser.add_argument(
-        "--jinja-env-params",
-        "-J",
-        dest="jinja_env_params",
-        action="append",
-        help="List of key=value pairs separated by comma. These values are fed into the jinja2.Environment as is.",
-        type=str,
+        "--trim-whitespace",
+        help="Allow customising whitespace control in Jinja templates."
+             "Providing the flag will enable both `lstrip_blocks` and `trim_blocks`",
+        required=False,
+        action="store_true",
     )
 
 

--- a/semantic-conventions/src/opentelemetry/semconv/main.py
+++ b/semantic-conventions/src/opentelemetry/semconv/main.py
@@ -69,7 +69,7 @@ def main():
     if len(semconv.models) == 0:
         parser.error("No semantic convention model found!")
     if args.flavor == "code":
-        renderer = CodeRenderer.from_commandline_params(args.parameters)
+        renderer = CodeRenderer.from_commandline_params(args.parameters, args.jinja_env_params)
         renderer.render(semconv, args.template, args.output, args.pattern)
     elif args.flavor == "markdown":
         process_markdown(semconv, args)
@@ -136,6 +136,14 @@ def add_code_parser(subparsers):
         dest="parameters",
         action="append",
         help="List of key=value pairs separated by comma. These values are fed into the template as is.",
+        type=str,
+    )
+    parser.add_argument(
+        "--jinja-env-params",
+        "-J",
+        dest="jinja_env_params",
+        action="append",
+        help="List of key=value pairs separated by comma. These values are fed into the jinja2.Environment as is.",
         type=str,
     )
 

--- a/semantic-conventions/src/opentelemetry/semconv/main.py
+++ b/semantic-conventions/src/opentelemetry/semconv/main.py
@@ -143,7 +143,7 @@ def add_code_parser(subparsers):
     parser.add_argument(
         "--trim-whitespace",
         help="Allow customising whitespace control in Jinja templates."
-             "Providing the flag will enable both `lstrip_blocks` and `trim_blocks`",
+        "Providing the flag will enable both `lstrip_blocks` and `trim_blocks`",
         required=False,
         action="store_true",
     )

--- a/semantic-conventions/src/opentelemetry/semconv/main.py
+++ b/semantic-conventions/src/opentelemetry/semconv/main.py
@@ -69,7 +69,9 @@ def main():
     if len(semconv.models) == 0:
         parser.error("No semantic convention model found!")
     if args.flavor == "code":
-        renderer = CodeRenderer.from_commandline_params(args.parameters, args.jinja_env_params)
+        renderer = CodeRenderer.from_commandline_params(
+            args.parameters, args.jinja_env_params
+        )
         renderer.render(semconv, args.template, args.output, args.pattern)
     elif args.flavor == "markdown":
         process_markdown(semconv, args)

--- a/semantic-conventions/src/opentelemetry/semconv/main.py
+++ b/semantic-conventions/src/opentelemetry/semconv/main.py
@@ -143,7 +143,7 @@ def add_code_parser(subparsers):
     parser.add_argument(
         "--trim-whitespace",
         help="Allow customising whitespace control in Jinja templates."
-        "Providing the flag will enable both `lstrip_blocks` and `trim_blocks`",
+        " Providing the flag will enable both `lstrip_blocks` and `trim_blocks`",
         required=False,
         action="store_true",
     )

--- a/semantic-conventions/src/opentelemetry/semconv/templating/code.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/code.py
@@ -209,7 +209,7 @@ class CodeRenderer:
 
         for param in jinja_env_params:
             val = jinja_env_params[param]
-            if val == "True" or val == "False":
+            if val in ("True", "False"):
                 setattr(env, param, bool(strtobool(str(val))))
             else:
                 setattr(env, param, val)

--- a/semantic-conventions/src/opentelemetry/semconv/templating/code.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/code.py
@@ -168,12 +168,12 @@ class CodeRenderer:
     def from_commandline_params(parameters=None, jinja_env_params=None):
         return CodeRenderer(
             CodeRenderer.parse_key_value_params(parameters),
-            CodeRenderer.parse_key_value_params(jinja_env_params)
+            CodeRenderer.parse_key_value_params(jinja_env_params),
         )
 
-    def __init__(self,
-                 parameters: typing.Dict[str, str],
-                 jinja_env_params: typing.Dict[str, str]):
+    def __init__(
+        self, parameters: typing.Dict[str, str], jinja_env_params: typing.Dict[str, str]
+    ):
         self.parameters = parameters
         self.jinja_env_params = jinja_env_params
 
@@ -209,7 +209,7 @@ class CodeRenderer:
 
         for param in jinja_env_params:
             val = jinja_env_params[param]
-            if (val == 'True' or val == 'False'):
+            if val == "True" or val == "False":
                 setattr(env, param, bool(strtobool(str(val))))
             else:
                 setattr(env, param, val)
@@ -245,7 +245,7 @@ class CodeRenderer:
         folder = os.path.dirname(template_path)
         env = Environment(
             loader=FileSystemLoader(searchpath=folder),
-            autoescape=select_autoescape([""])
+            autoescape=select_autoescape([""]),
         )
         self.setup_environment(env, self.jinja_env_params)
         if pattern:

--- a/semantic-conventions/src/opentelemetry/semconv/templating/code.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/code.py
@@ -209,7 +209,7 @@ class CodeRenderer:
 
         for param in jinja_env_params:
             val = jinja_env_params[param]
-            if val in ("True", "False"):
+            if val.lower() in ("true", "false"):
                 setattr(env, param, bool(strtobool(str(val))))
             else:
                 setattr(env, param, val)

--- a/semantic-conventions/src/opentelemetry/semconv/templating/code.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/code.py
@@ -209,8 +209,8 @@ class CodeRenderer:
         env.filters["to_html_links"] = to_html_links
         env.filters["regex_replace"] = regex_replace
         env.filters["render_markdown"] = render_markdown
-        setattr(env, "trim_blocks", trim_whitespace)
-        setattr(env, "lstrip_blocks", trim_whitespace)
+        env.trim_blocks = trim_whitespace
+        env.lstrip_blocks = trim_whitespace
 
     @staticmethod
     def prefix_output_file(file_name, pattern, semconv):

--- a/semantic-conventions/src/tests/data/jinja/metrics/expected_no_whitespace.java
+++ b/semantic-conventions/src/tests/data/jinja/metrics/expected_no_whitespace.java
@@ -1,0 +1,19 @@
+package io.opentelemetry.instrumentation.api.metric;
+
+class Units {
+    /**
+    * Use this unit for Metric Instruments recording values
+    * representing fraction of a total.
+    **/
+    public static final String PERCENT = "%";
+    /**
+    * Use this unit for Metric Instruments recording values
+    * representing time.
+    **/
+    public static final String NANOSECOND = "NS";
+    /**
+    * Use this unit for Metric Instruments recording values
+    * representing connections.
+    **/
+    public static final String CONNECTIONS = "{connections}";
+}

--- a/semantic-conventions/src/tests/data/jinja/metrics/expected_trim_whitespace_enabled.java
+++ b/semantic-conventions/src/tests/data/jinja/metrics/expected_trim_whitespace_enabled.java
@@ -1,16 +1,19 @@
 package io.opentelemetry.instrumentation.api.metric;
 
 class Units {
+
     /**
     * Use this unit for Metric Instruments recording values
     * representing fraction of a total.
     **/
     public static final String PERCENT = "%";
+
     /**
     * Use this unit for Metric Instruments recording values
     * representing time.
     **/
     public static final String NANOSECOND = "NS";
+
     /**
     * Use this unit for Metric Instruments recording values
     * representing connections.

--- a/semantic-conventions/src/tests/data/jinja/metrics/units_template_trim_whitespace_enabled
+++ b/semantic-conventions/src/tests/data/jinja/metrics/units_template_trim_whitespace_enabled
@@ -1,0 +1,13 @@
+package io.opentelemetry.instrumentation.api.metric;
+
+class Units {
+{% for member in semconvs['units'].members.values() %}{% set constant_name = member.id.upper() %}
+
+    /**
+    * Use this unit for Metric Instruments recording values
+    * representing {{member.brief}}.
+    **/
+    public static final String {{constant_name}} = "{{member.value}}";
+{% endfor %}
+}
+

--- a/semantic-conventions/src/tests/semconv/templating/test_code.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_code.py
@@ -1,5 +1,7 @@
 import io
 
+import pytest
+
 from opentelemetry.semconv.model.semantic_convention import SemanticConventionSet
 from opentelemetry.semconv.templating.code import CodeRenderer
 
@@ -21,14 +23,15 @@ def test_codegen_units(test_file_path, read_test_file):
     assert result == expected
 
 
-def test_strip_blocks_enabled(test_file_path, read_test_file):
+@pytest.mark.parametrize("trim_blocks, lstrip_blocks", [("True", "True"), ("true", "TRUE"), ("TRUE", "tRuE")])
+def test_strip_blocks_enabled(test_file_path, read_test_file, trim_blocks, lstrip_blocks):
     """Tests that Jinja config options are passed to the Jinja environment"""
     semconv = SemanticConventionSet(debug=False)
     semconv.parse(test_file_path("yaml", "metrics", "units.yaml"))
     semconv.finish()
 
     template_path = test_file_path("jinja", "metrics", "units_template")
-    renderer = CodeRenderer({}, {"trim_blocks": "True", "lstrip_blocks": "True"})
+    renderer = CodeRenderer({}, {"trim_blocks": trim_blocks, "lstrip_blocks": lstrip_blocks})
 
     output = io.StringIO()
     renderer.render(semconv, template_path, output, None)

--- a/semantic-conventions/src/tests/semconv/templating/test_code.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_code.py
@@ -1,7 +1,5 @@
 import io
 
-import pytest
-
 from opentelemetry.semconv.model.semantic_convention import SemanticConventionSet
 from opentelemetry.semconv.templating.code import CodeRenderer
 
@@ -12,7 +10,7 @@ def test_codegen_units(test_file_path, read_test_file):
     semconv.finish()
 
     template_path = test_file_path("jinja", "metrics", "units_template")
-    renderer = CodeRenderer({}, {})
+    renderer = CodeRenderer({}, False)
 
     output = io.StringIO()
     renderer.render(semconv, template_path, output, None)
@@ -23,21 +21,14 @@ def test_codegen_units(test_file_path, read_test_file):
     assert result == expected
 
 
-@pytest.mark.parametrize(
-    "trim_blocks, lstrip_blocks", [("True", "True"), ("true", "TRUE"), ("TRUE", "tRuE")]
-)
-def test_strip_blocks_enabled(
-    test_file_path, read_test_file, trim_blocks, lstrip_blocks
-):
-    """Tests that Jinja config options are passed to the Jinja environment"""
+def test_strip_blocks_enabled(test_file_path, read_test_file):
+    """Tests that the Jinja whitespace control params are fed to the Jinja environment"""
     semconv = SemanticConventionSet(debug=False)
     semconv.parse(test_file_path("yaml", "metrics", "units.yaml"))
     semconv.finish()
 
     template_path = test_file_path("jinja", "metrics", "units_template")
-    renderer = CodeRenderer(
-        {}, {"trim_blocks": trim_blocks, "lstrip_blocks": lstrip_blocks}
-    )
+    renderer = CodeRenderer({}, True)
 
     output = io.StringIO()
     renderer.render(semconv, template_path, output, None)

--- a/semantic-conventions/src/tests/semconv/templating/test_code.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_code.py
@@ -22,6 +22,7 @@ def test_codegen_units(test_file_path, read_test_file):
 
 
 def test_strip_blocks_enabled(test_file_path, read_test_file):
+    """Tests that Jinja config options are passed to the Jinja environment"""
     semconv = SemanticConventionSet(debug=False)
     semconv.parse(test_file_path("yaml", "metrics", "units.yaml"))
     semconv.finish()

--- a/semantic-conventions/src/tests/semconv/templating/test_code.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_code.py
@@ -27,7 +27,7 @@ def test_strip_blocks_enabled(test_file_path, read_test_file):
     semconv.finish()
 
     template_path = test_file_path("jinja", "metrics", "units_template")
-    renderer = CodeRenderer({}, {'trim_blocks': 'True', 'lstrip_blocks': 'True'})
+    renderer = CodeRenderer({}, {"trim_blocks": "True", "lstrip_blocks": "True"})
 
     output = io.StringIO()
     renderer.render(semconv, template_path, output, None)

--- a/semantic-conventions/src/tests/semconv/templating/test_code.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_code.py
@@ -23,15 +23,21 @@ def test_codegen_units(test_file_path, read_test_file):
     assert result == expected
 
 
-@pytest.mark.parametrize("trim_blocks, lstrip_blocks", [("True", "True"), ("true", "TRUE"), ("TRUE", "tRuE")])
-def test_strip_blocks_enabled(test_file_path, read_test_file, trim_blocks, lstrip_blocks):
+@pytest.mark.parametrize(
+    "trim_blocks, lstrip_blocks", [("True", "True"), ("true", "TRUE"), ("TRUE", "tRuE")]
+)
+def test_strip_blocks_enabled(
+    test_file_path, read_test_file, trim_blocks, lstrip_blocks
+):
     """Tests that Jinja config options are passed to the Jinja environment"""
     semconv = SemanticConventionSet(debug=False)
     semconv.parse(test_file_path("yaml", "metrics", "units.yaml"))
     semconv.finish()
 
     template_path = test_file_path("jinja", "metrics", "units_template")
-    renderer = CodeRenderer({}, {"trim_blocks": trim_blocks, "lstrip_blocks": lstrip_blocks})
+    renderer = CodeRenderer(
+        {}, {"trim_blocks": trim_blocks, "lstrip_blocks": lstrip_blocks}
+    )
 
     output = io.StringIO()
     renderer.render(semconv, template_path, output, None)

--- a/semantic-conventions/src/tests/semconv/templating/test_code.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_code.py
@@ -10,12 +10,29 @@ def test_codegen_units(test_file_path, read_test_file):
     semconv.finish()
 
     template_path = test_file_path("jinja", "metrics", "units_template")
-    renderer = CodeRenderer({})
+    renderer = CodeRenderer({}, {})
 
     output = io.StringIO()
     renderer.render(semconv, template_path, output, None)
     result = output.getvalue()
 
     expected = read_test_file("jinja", "metrics", "expected.java")
+
+    assert result == expected
+
+
+def test_strip_blocks_enabled(test_file_path, read_test_file):
+    semconv = SemanticConventionSet(debug=False)
+    semconv.parse(test_file_path("yaml", "metrics", "units.yaml"))
+    semconv.finish()
+
+    template_path = test_file_path("jinja", "metrics", "units_template")
+    renderer = CodeRenderer({}, {'trim_blocks': 'True', 'lstrip_blocks': 'True'})
+
+    output = io.StringIO()
+    renderer.render(semconv, template_path, output, None)
+    result = output.getvalue()
+
+    expected = read_test_file("jinja", "metrics", "expected_no_whitespace.java")
 
     assert result == expected

--- a/semantic-conventions/src/tests/semconv/templating/test_code.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_code.py
@@ -10,7 +10,7 @@ def test_codegen_units(test_file_path, read_test_file):
     semconv.finish()
 
     template_path = test_file_path("jinja", "metrics", "units_template")
-    renderer = CodeRenderer({}, False)
+    renderer = CodeRenderer({}, trim_whitespace=False)
 
     output = io.StringIO()
     renderer.render(semconv, template_path, output, None)
@@ -27,13 +27,17 @@ def test_strip_blocks_enabled(test_file_path, read_test_file):
     semconv.parse(test_file_path("yaml", "metrics", "units.yaml"))
     semconv.finish()
 
-    template_path = test_file_path("jinja", "metrics", "units_template")
-    renderer = CodeRenderer({}, True)
+    template_path = test_file_path(
+        "jinja", "metrics", "units_template_trim_whitespace_enabled"
+    )
+    renderer = CodeRenderer({}, trim_whitespace=True)
 
     output = io.StringIO()
     renderer.render(semconv, template_path, output, None)
     result = output.getvalue()
 
-    expected = read_test_file("jinja", "metrics", "expected_no_whitespace.java")
+    expected = read_test_file(
+        "jinja", "metrics", "expected_trim_whitespace_enabled.java"
+    )
 
     assert result == expected


### PR DESCRIPTION
Sometimes it might be desired to customize the Jinja Environment. For example, it might be useful to enable the features in Jinja to [strip/trim blocks to make it easier to control whitespace](https://jinja.palletsprojects.com/en/3.1.x/templates/#whitespace-control) rendering in templates.

This PR adds a possibility to ~~pass multiple parameters (similar as the params that are fed into the template)which are passed into the `jinja2.Environment` as is.~~ provide a new flag `--trim-whitespace` which enables both `trim_blocks` and `lstrip_blocks` in the Jinja environment

I came into this, while working on using the semconv code tool to generate the code files for the conventions in .NET: https://github.com/open-telemetry/opentelemetry-dotnet/pull/2069

It proved very challenging to manage the whites paces/new lines and make the generated `.cs` file look right. In the end it got complex with the `{%-` option in jinja. I tried leaving it as is and using `dotnet format` but that also brought a myriad of other problems.

Now with strip/trim enabled, actual white space/new lines are rendered as is and it is MUCH easier to read and understand what the template is doing and what to expect of an output. 

The usage of it would be:

```bash
docker run --rm \
  -v ${SCRIPT_DIR}/opentelemetry-specification/semantic_conventions/trace:/source \
  -v ${SCRIPT_DIR}/templates:/templates \
  -v ${ROOT_DIR}/Trace:/output \
  semconvgen \
  -f /source code \
  --template /templates/SemanticConventions.cs.j2 \
  --output /output/TraceSemanticConventions.cs \
  --trim-whitespace \ -> new flag
  -Dclass=TraceSemanticConventions \
  -DschemaUrl=$SCHEMA_URL \
  -Dpkg=OpenTelemetry.Trace
```