### PR TITLE
Apply requirement level and msg of referenced attribute by default

### DIFF
--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
@@ -136,7 +136,7 @@ class SemanticAttribute:
             required_value_map = {
                 "required": RequirementLevel.REQUIRED,
                 "conditionally_required": RequirementLevel.CONDITIONALLY_REQUIRED,
-                "": RequirementLevel.RECOMMENDED,
+                "": None,
                 "recommended": RequirementLevel.RECOMMENDED,
                 "optional": RequirementLevel.OPTIONAL,
             }
@@ -163,7 +163,7 @@ class SemanticAttribute:
             else:
                 requirement_level = required_value_map.get(requirement_level_val)
 
-            if requirement_level is None:
+            if requirement_level_val and requirement_level is None:
                 position = position_data["requirement_level"]
                 msg = "Value '{}' for required field is not allowed".format(
                     requirement_level_val

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
@@ -60,7 +60,7 @@ class SemanticAttribute:
     tag: str
     stability: StabilityLevel
     deprecated: str
-    requirement_level: RequirementLevel
+    requirement_level: Optional[RequirementLevel]
     requirement_level_msg: str
     sampling_relevant: bool
     note: str
@@ -136,7 +136,6 @@ class SemanticAttribute:
             required_value_map = {
                 "required": RequirementLevel.REQUIRED,
                 "conditionally_required": RequirementLevel.CONDITIONALLY_REQUIRED,
-                "": None,
                 "recommended": RequirementLevel.RECOMMENDED,
                 "optional": RequirementLevel.OPTIONAL,
             }

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -461,7 +461,8 @@ class SemanticConventionSet:
                     attr.brief = ref_attr.brief
                 if not attr.requirement_level:
                     attr.requirement_level = ref_attr.requirement_level
-                    attr.requirement_level_msg = ref_attr.requirement_level_msg
+                    if not attr.requirement_level_msg:
+                        attr.requirement_level_msg = ref_attr.requirement_level_msg
                 if not attr.note:
                     attr.note = ref_attr.note
                 if attr.examples is None:

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -459,6 +459,10 @@ class SemanticConventionSet:
                 attr.attr_type = ref_attr.attr_type
                 if not attr.brief:
                     attr.brief = ref_attr.brief
+                if not attr.requirement_level:
+                    attr.requirement_level = ref_attr.requirement_level
+                if not attr.requirement_level_msg:
+                    attr.requirement_level_msg = ref_attr.requirement_level_msg
                 if not attr.note:
                     attr.note = ref_attr.note
                 if attr.examples is None:

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -461,7 +461,6 @@ class SemanticConventionSet:
                     attr.brief = ref_attr.brief
                 if not attr.requirement_level:
                     attr.requirement_level = ref_attr.requirement_level
-                if not attr.requirement_level_msg:
                     attr.requirement_level_msg = ref_attr.requirement_level_msg
                 if not attr.note:
                     attr.note = ref_attr.note

--- a/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
@@ -163,7 +163,7 @@ class MarkdownRenderer:
                 )
         elif attribute.requirement_level == RequirementLevel.OPTIONAL:
             required = "Optional"
-        else:  # attribute.requirement_level == Required.RECOMMENDED
+        else:  # attribute.requirement_level == Required.RECOMMENDED or None
             # check if there are any notes
             if (
                 not self.render_ctx.is_remove_constraint

--- a/semantic-conventions/src/tests/data/markdown/ref/expected.md
+++ b/semantic-conventions/src/tests/data/markdown/ref/expected.md
@@ -6,6 +6,8 @@
 | `rpc.service` | string | The service name, must be equal to the $service part in the span name. | `EchoService` | Required |
 | [`net.peer.name`](input_general.md) | string | override brief. [1] | `example.com` | Optional |
 | [`net.peer.port`](input_general.md) | int | It describes the server port the client is connecting to | `80`; `8080`; `443` | Required |
+| [`net.sock.peer.addr`](input_general.md) | string | Remote socket peer address. | `127.0.0.1`; `/tmp/mysql.sock` | Required |
+| [`net.sock.peer.port`](input_general.md) | int | Remote socket peer port. | `16456` | Recommended: <condition> |
 
 **[1]:** override note.
 

--- a/semantic-conventions/src/tests/data/markdown/ref/expected.md
+++ b/semantic-conventions/src/tests/data/markdown/ref/expected.md
@@ -7,7 +7,7 @@
 | [`net.peer.name`](input_general.md) | string | override brief. [1] | `example.com` | Optional |
 | [`net.peer.port`](input_general.md) | int | It describes the server port the client is connecting to | `80`; `8080`; `443` | Required |
 | [`net.sock.peer.addr`](input_general.md) | string | Remote socket peer address. | `127.0.0.1`; `/tmp/mysql.sock` | Required |
-| [`net.sock.peer.port`](input_general.md) | int | Remote socket peer port. | `16456` | Recommended: <condition> |
+| [`net.sock.peer.port`](input_general.md) | int | Remote socket peer port. | `16456` | Conditionally Required: <condition> |
 
 **[1]:** override note.
 

--- a/semantic-conventions/src/tests/data/markdown/ref/general.yaml
+++ b/semantic-conventions/src/tests/data/markdown/ref/general.yaml
@@ -46,7 +46,7 @@ groups:
         type: int
         brief: Remote socket peer port.
         requirement_level:
-          recommended: <condition>
+          conditionally_required: <condition>
         examples: 16456
   - id: identity
     prefix: enduser

--- a/semantic-conventions/src/tests/data/markdown/ref/general.yaml
+++ b/semantic-conventions/src/tests/data/markdown/ref/general.yaml
@@ -31,6 +31,23 @@ groups:
         type: string
         brief: 'Local hostname or similar, see note below.'
         examples: 'localhost'
+      - id: sock.peer.name
+        type: string
+        brief: Remote socket peer name.
+        requirement_level:
+          recommended: If available and different than `net.peer.name` and if `net.sock.peer.addr` is set.
+        examples: proxy.example.com
+      - id: sock.peer.addr
+        type: string
+        brief: >
+          Remote socket peer address.
+        examples: ['127.0.0.1', '/tmp/mysql.sock' ]
+      - id: sock.peer.port
+        type: int
+        brief: Remote socket peer port.
+        requirement_level:
+          recommended: <condition>
+        examples: 16456
   - id: identity
     prefix: enduser
     type: span

--- a/semantic-conventions/src/tests/data/markdown/ref/rpc.yaml
+++ b/semantic-conventions/src/tests/data/markdown/ref/rpc.yaml
@@ -26,6 +26,10 @@ groups:
         requirement_level: optional
         brief: override brief.
         note: override note.
+      - ref: net.sock.peer.addr
+        requirement_level: required # override level
+      - ref: net.sock.peer.port
+
   - id: grpc.server
     type: span
     extends: rpc


### PR DESCRIPTION
If the requirement level is not overridden when referencing an attribute, we should reuse the original one