### PR TITLE
Workflows: Specify python version: setup-python@v4 compat.

### DIFF
--- a/.github/workflows/semconvgen.yml
+++ b/.github/workflows/semconvgen.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
     - name: install dev-dependencies
       run: |
         pip install -U pip


### PR DESCRIPTION
Required for dependabot's open-telemetry/build-tools#100