### PR TITLE
Update schema check tool to support Schema File version 1.1.0

### DIFF
--- a/schemas/go.mod
+++ b/schemas/go.mod
@@ -4,8 +4,8 @@ go 1.17
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
-	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel/schema v0.0.2
+	github.com/stretchr/testify v1.7.1
+	go.opentelemetry.io/otel/schema v0.0.3-0.20220725153023-1eae91b3b099
 )
 
 require (

--- a/schemas/go.sum
+++ b/schemas/go.sum
@@ -5,10 +5,10 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-go.opentelemetry.io/otel/schema v0.0.2 h1:PqadNg9PGGI2/9F9yuvOglu868Hded24v9yOJ2dlBWc=
-go.opentelemetry.io/otel/schema v0.0.2/go.mod h1:knHeVSWnzKRTcznXuwsuWCvO4sGybDbj/o7IKnG36xQ=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+go.opentelemetry.io/otel/schema v0.0.3-0.20220725153023-1eae91b3b099 h1:XYbYk+7V0+q/gEY0tklw1wjqmeYwheXLGAHOfjPuC2I=
+go.opentelemetry.io/otel/schema v0.0.3-0.20220725153023-1eae91b3b099/go.mod h1:SVJ5rsfaNzJ8JV++F7gwqRNRUCsISldY/YpcWSE+oT0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/schemas/main.go
+++ b/schemas/main.go
@@ -7,8 +7,8 @@ import (
 	"os"
 
 	"github.com/Masterminds/semver/v3"
-	schema "go.opentelemetry.io/otel/schema/v1.0"
-	"go.opentelemetry.io/otel/schema/v1.0/types"
+	schema "go.opentelemetry.io/otel/schema/v1.1"
+	"go.opentelemetry.io/otel/schema/v1.1/types"
 )
 
 var schemaFilePath = flag.String("file", "", "Input schema file path")
@@ -21,8 +21,8 @@ func loadSchemaFromFile(schemaFilePath string, schemaVersion string) error {
 		return err
 	}
 
-	// We only support a specific format version.
-	if telSchema.FileFormat != "1.0.0" {
+	// We only support specific format versions.
+	if telSchema.FileFormat != "1.0.0" && telSchema.FileFormat != "1.1.0" {
 		return fmt.Errorf("incorrect schema file format version: %s", telSchema.FileFormat)
 	}
 

--- a/schemas/main_test.go
+++ b/schemas/main_test.go
@@ -12,6 +12,9 @@ func TestValidSchema(t *testing.T) {
 
 	err = loadSchemaFromFile("testdata/1.9.0", "1.9.0")
 	assert.NoError(t, err)
+
+	err = loadSchemaFromFile("testdata/1.13.0-example", "1.13.0")
+	assert.NoError(t, err)
 }
 
 func TestInvalidSchemas(t *testing.T) {

--- a/schemas/testdata/1.13.0-example
+++ b/schemas/testdata/1.13.0-example
@@ -1,0 +1,35 @@
+# This is an example of what Otel 1.13.0 schema file can look like (the real one
+# will probably have more transformations - we only have one "split" just for
+# testing purposes).
+file_format: 1.1.0
+schema_url: https://opentelemetry.io/schemas/1.13.0
+versions:
+  1.13.0:
+    metrics:
+        # Definitions that apply to Metric data type.
+        changes:
+          - split:
+              # Example from the change done by https://github.com/open-telemetry/opentelemetry-specification/pull/2617
+              # Name of old metric to split.
+              apply_to_metric: system.paging.operations
+              # Name of attribute in the old metric to use for splitting. The attribute will be
+              # eliminated, the new metric will not have it.
+              by_attribute: direction
+              # Names of new metrics to create, one for each possible value of attribute.
+              metrics_from_attributes:
+                # If "direction" attribute equals "in" create a new metric called "system.paging.operations.in".
+                system.paging.operations.in: in
+                # If "direction" attribute equals "out" create a new metric called "system.paging.operations.out".
+                system.paging.operations.out: out
+  1.9.0:
+  1.8.0:
+    spans:
+      changes:
+        - rename_attributes:
+            attribute_map:
+              db.cassandra.keyspace: db.name
+              db.hbase.namespace: db.name
+  1.7.0:
+  1.6.1:
+  1.5.0:
+  1.4.0:


### PR DESCRIPTION
- Pinned to specific commit 1eae91b3b099af62100cd630cd1cab89fe841615
  of https://github.com/open-telemetry/opentelemetry-go to be able
  to use schema file version 1.1.0 parser.