### PR TITLE
Clarify warning & fix line number

### DIFF
--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -72,9 +72,10 @@ def SemanticConvention(group):
     type_value = group.get("type")
     if type_value is None:
         line = group.lc.data["id"][0] + 1
+        doc_url = "https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups"
         print(
-            "Please set the type for group '{}' on line {} - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups".format(
-                group["id"], line
+            "Please set the type for group '{}' on line {} - defaulting to type 'span'. See {}".format(
+                group["id"], line, doc_url
             ),
             file=sys.stderr,
         )

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -71,9 +71,9 @@ def parse_semantic_convention_groups(yaml_file):
 def SemanticConvention(group):
     type_value = group.get("type")
     if type_value is None:
-        line = group.lc.data["id"][1] + 1
+        line = group.lc.data["id"][0] + 1
         print(
-            "Using default SPAN type for semantic convention '{}' @ line {}".format(
+            "Please set the type for group '{}' on line {} - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups".format(
                 group["id"], line
             ),
             file=sys.stderr,


### PR DESCRIPTION
https://github.com/open-telemetry/build-tools/pull/107 established that this warning is intended to advise users to set the type for a group. This PR is to:

- [x] Clarify the message, including a link to the documentation for the type.
- [x] Fix the line number (previously the line number was always `5`)

> _From `syntax.md`_...
> - `type`, optional enum, defaults to `span` (with a warning if not present).

I would love to add some language to this ☝🏻 section of the `syntax.md` document, further explaining what a group's `type` field means. Unfortunately, I don't know what it means. Could anyone suggest some further explanation?