### PR TITLE
Add scope semantic conventions as a type

### DIFF
--- a/semantic-conventions/CHANGELOG.md
+++ b/semantic-conventions/CHANGELOG.md
@@ -4,7 +4,8 @@ Please update the changelog as part of any significant pull request.
 
 ## Unreleased
 
-- ...
+- Add "scope" as a span type
+  ([#114](https://github.com/open-telemetry/build-tools/pull/114)).
 
 ## v0.13.0
 

--- a/semantic-conventions/CHANGELOG.md
+++ b/semantic-conventions/CHANGELOG.md
@@ -4,7 +4,7 @@ Please update the changelog as part of any significant pull request.
 
 ## Unreleased
 
-- Add "scope" as a span type
+- Add a semantic convention type for Instrumentation Scope ("scope")
   ([#114](https://github.com/open-telemetry/build-tools/pull/114)).
 
 ## v0.13.0

--- a/semantic-conventions/semconv.schema.json
+++ b/semantic-conventions/semconv.schema.json
@@ -51,7 +51,8 @@
 						"span",
 						"resource",
 						"metric",
-						"event"
+						"event",
+						"scope"
 					],
 					"description": "The (signal) type of the semantic convention"
 				},

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -194,6 +194,10 @@ class ResourceSemanticConvention(BaseSemanticConvention):
     GROUP_TYPE_NAME = "resource"
 
 
+class ScopeSemanticConvention(BaseSemanticConvention):
+    GROUP_TYPE_NAME = "scope"
+
+
 class SpanSemanticConvention(BaseSemanticConvention):
     GROUP_TYPE_NAME = "span"
 
@@ -541,5 +545,6 @@ CONVENTION_CLS_BY_GROUP_TYPE = {
         EventSemanticConvention,
         MetricSemanticConvention,
         UnitSemanticConvention,
+        ScopeSemanticConvention,
     )
 }

--- a/semantic-conventions/src/tests/data/markdown/scope/expected.md
+++ b/semantic-conventions/src/tests/data/markdown/scope/expected.md
@@ -1,0 +1,7 @@
+# Instrumentation Scope Semantic Conventions
+
+<!-- semconv scope -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| `scope.short_name` | string | The single-word name for the instrumentation scope. | `mylibrary` | Recommended |
+<!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/markdown/scope/expected.md
+++ b/semantic-conventions/src/tests/data/markdown/scope/expected.md
@@ -3,5 +3,5 @@
 <!-- semconv scope -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `scope.short_name` | string | The single-word name for the instrumentation scope. | `mylibrary` | Recommended |
+| `short_name` | string | The single-word name for the instrumentation scope. | `mylibrary` | Recommended |
 <!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/markdown/scope/input.md
+++ b/semantic-conventions/src/tests/data/markdown/scope/input.md
@@ -1,0 +1,4 @@
+# Instrumentation Scope Semantic Conventions
+
+<!-- semconv scope -->
+<!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/markdown/scope/scope.yaml
+++ b/semantic-conventions/src/tests/data/markdown/scope/scope.yaml
@@ -1,6 +1,6 @@
 groups:
   - id: scope
-    prefix:
+    prefix: ""
     type: scope
     brief: >
       Instrumentation Scope attributes

--- a/semantic-conventions/src/tests/data/markdown/scope/scope.yaml
+++ b/semantic-conventions/src/tests/data/markdown/scope/scope.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: scope
-    prefix: scope
+    prefix:
+    type: scope
     brief: >
       Instrumentation Scope attributes
     attributes:

--- a/semantic-conventions/src/tests/data/markdown/scope/scope.yaml
+++ b/semantic-conventions/src/tests/data/markdown/scope/scope.yaml
@@ -1,0 +1,12 @@
+groups:
+  - id: scope
+    prefix: scope
+    brief: >
+      Instrumentation Scope attributes
+    attributes:
+      - id: short_name
+        type: string
+        requirement_level: recommended
+        brief: >
+          The single-word name for the instrumentation scope.
+        examples: ['mylibrary']

--- a/semantic-conventions/src/tests/data/yaml/scope.yaml
+++ b/semantic-conventions/src/tests/data/yaml/scope.yaml
@@ -1,6 +1,6 @@
 groups:
   - id: scope-id
-    prefix: scopeprefix
+    prefix:
     type: scope
     brief: >
       Instrumentation Scope attributes

--- a/semantic-conventions/src/tests/data/yaml/scope.yaml
+++ b/semantic-conventions/src/tests/data/yaml/scope.yaml
@@ -1,6 +1,7 @@
 groups:
-  - id: scope
-    prefix: scope
+  - id: scope-id
+    prefix: scopeprefix
+    type: scope
     brief: >
       Instrumentation Scope attributes
     attributes:

--- a/semantic-conventions/src/tests/data/yaml/scope.yaml
+++ b/semantic-conventions/src/tests/data/yaml/scope.yaml
@@ -1,0 +1,12 @@
+groups:
+  - id: scope
+    prefix: scope
+    brief: >
+      Instrumentation Scope attributes
+    attributes:
+      - id: short_name
+        type: string
+        requirement_level: recommended
+        brief: >
+          The single-word name for the instrumentation scope.
+        examples: ['mylibrary']

--- a/semantic-conventions/src/tests/data/yaml/scope.yaml
+++ b/semantic-conventions/src/tests/data/yaml/scope.yaml
@@ -1,6 +1,6 @@
 groups:
   - id: scope-id
-    prefix:
+    prefix: ""
     type: scope
     brief: >
       Instrumentation Scope attributes

--- a/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
+++ b/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
@@ -669,6 +669,23 @@ class TestCorrectParse(unittest.TestCase):
         self.assertEqual(expected["n_constraints"], len(s.constraints))
         self.assertEqual(expected["attributes"], [a.fqn for a in s.attributes])
 
+    def test_scope_attribute(self):
+        semconv = SemanticConventionSet(debug=False)
+        semconv.parse(self.load_file("yaml/scope.yaml"))
+        self.assertEqual(len(semconv.models), 1)
+
+        expected = {
+            "id": "scope",
+            "prefix": "scope",
+            "extends": "",
+            "brief": "Instrumentation Scope attributes",
+            "n_constraints": 0,
+            "attributes": [
+                "scope.short_name",
+            ],
+        }
+        self.semantic_convention_check(list(semconv.models.values())[0], expected)
+
     _TEST_DIR = os.path.dirname(__file__)
 
     def load_file(self, filename):

--- a/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
+++ b/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
@@ -676,13 +676,13 @@ class TestCorrectParse(unittest.TestCase):
 
         expected = {
             "id": "scope-id",
-            "prefix": "scopeprefix",
+            "prefix": "",
             "type": "scope",
             "extends": "",
             "brief": "Instrumentation Scope attributes",
             "n_constraints": 0,
             "attributes": [
-                "scopeprefix.short_name",
+                "short_name",
             ],
         }
         self.semantic_convention_check(list(semconv.models.values())[0], expected)

--- a/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
+++ b/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
@@ -675,13 +675,14 @@ class TestCorrectParse(unittest.TestCase):
         self.assertEqual(len(semconv.models), 1)
 
         expected = {
-            "id": "scope",
-            "prefix": "scope",
+            "id": "scope-id",
+            "prefix": "scopeprefix",
+            "type": "scope",
             "extends": "",
             "brief": "Instrumentation Scope attributes",
             "n_constraints": 0,
             "attributes": [
-                "scope.short_name",
+                "scopeprefix.short_name",
             ],
         }
         self.semantic_convention_check(list(semconv.models.values())[0], expected)

--- a/semantic-conventions/src/tests/semconv/templating/test_markdown.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_markdown.py
@@ -126,6 +126,9 @@ class TestCorrectMarkdown(unittest.TestCase):
     def testSamplingRelevant(self):
         self.check("markdown/sampling_relevant/")
 
+    def testScope(self):
+        self.check("markdown/scope/")
+
     def check(
         self,
         input_dir: str,

--- a/semantic-conventions/src/tests/semconv/templating/test_markdown.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_markdown.py
@@ -126,7 +126,7 @@ class TestCorrectMarkdown(unittest.TestCase):
     def testSamplingRelevant(self):
         self.check("markdown/sampling_relevant/")
 
-    def testScope(self):
+    def test_scope(self):
         self.check("markdown/scope/")
 
     def check(

--- a/semantic-conventions/syntax.md
+++ b/semantic-conventions/syntax.md
@@ -48,6 +48,7 @@ convtype ::= "span" # Default if not specified
          |   "resource" # see spanspecificfields
          |   "event"    # see eventspecificfields
          |   "metric"   # (currently non-functional)
+         |   "scope"
 
 brief ::= string
 note  ::= string


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-specification/issues/2682

Addresses this comment: https://github.com/open-telemetry/opentelemetry-specification/pull/2702#discussion_r933096178

This adds "scope" as a semantic convention type.

cc @joaopgrassi