### PR TITLE
Build multiarch docker images on tag

### DIFF
--- a/.github/workflows/protobuf-dockerimage.yml
+++ b/.github/workflows/protobuf-dockerimage.yml
@@ -14,8 +14,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-
     # https://github.com/docker/setup-qemu-action
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
@@ -50,7 +48,6 @@ jobs:
     - name: Build and push
       uses: docker/build-push-action@v2
       with:
-        context: .
         file: ./protobuf/Dockerfile
         platforms: linux/amd64,linux/arm64
         push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/protobuf-dockerimage.yml
+++ b/.github/workflows/protobuf-dockerimage.yml
@@ -52,7 +52,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: "{{defaultContext}}:protobuf"
-        platforms: linux/amd64
+        platforms: linux/arm64
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/protobuf-dockerimage.yml
+++ b/.github/workflows/protobuf-dockerimage.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Build and push
       uses: docker/build-push-action@v2
       with:
-        file: ./protobuf/Dockerfile
+        file: protobuf/Dockerfile
         platforms: linux/amd64,linux/arm64
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/protobuf-dockerimage.yml
+++ b/.github/workflows/protobuf-dockerimage.yml
@@ -25,14 +25,6 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@v1
 
-    # https://github.com/docker/login-action
-    - name: Login to DockerHub
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-
     # https://github.com/docker/metadata-action
     - name: Docker meta
       id: meta
@@ -45,6 +37,14 @@ jobs:
         tags: |
           type=ref,event=tag
           type=semver,pattern={{version}}
+
+    # https://github.com/docker/login-action
+    - name: Login to DockerHub
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
 
     # https://github.com/docker/build-push-action
     - name: Build and push

--- a/.github/workflows/protobuf-dockerimage.yml
+++ b/.github/workflows/protobuf-dockerimage.yml
@@ -15,20 +15,45 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Build the Docker image
-      run: docker build protobuf/. -t build-protobuf
-    - name: Push the Docker image
-      if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
-      run: |
-        echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-        function tag_and_push {
-          docker tag build-protobuf "otel/build-protobuf:${1}" && docker push "otel/build-protobuf:${1}"
-        }
-        if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
-          tag_and_push "latest"
-        elif [[ "${GITHUB_REF}" =~ refs/tags/v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            TAG="${GITHUB_REF#"refs/tags/v"}"
-            tag_and_push "${TAG}"
-        else
-          tag_and_push "${GITHUB_REF#"refs/tags/"}"
-        fi
+
+    # https://github.com/docker/setup-qemu-action
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    # https://github.com/docker/setup-buildx-action
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+
+    # https://github.com/docker/login-action
+    - name: Login to DockerHub
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    # https://github.com/docker/metadata-action
+    - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            otel/build-protobuf
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=schedule
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+
+    # https://github.com/docker/build-push-action
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./protobuf/Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/protobuf-dockerimage.yml
+++ b/.github/workflows/protobuf-dockerimage.yml
@@ -51,8 +51,7 @@ jobs:
     - name: Build and push
       uses: docker/build-push-action@v2
       with:
-        context: .
-        file: protobuf/Dockerfile
+        context: "{{defaultContext}}:protobuf"
         platforms: linux/amd64,linux/arm64
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/protobuf-dockerimage.yml
+++ b/.github/workflows/protobuf-dockerimage.yml
@@ -35,17 +35,16 @@ jobs:
 
     # https://github.com/docker/metadata-action
     - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          # list of Docker images to use as base name for tags
-          images: |
-            otel/build-protobuf
-          # generate Docker tags based on the following events/attributes
-          tags: |
-            type=schedule
-            type=ref,event=tag
-            type=semver,pattern={{version}}
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        # list of Docker images to use as base name for tags
+        images: |
+          otel/build-protobuf
+        # generate Docker tags based on the following events/attributes
+        tags: |
+          type=ref,event=tag
+          type=semver,pattern={{version}}
 
     # https://github.com/docker/build-push-action
     - name: Build and push

--- a/.github/workflows/protobuf-dockerimage.yml
+++ b/.github/workflows/protobuf-dockerimage.yml
@@ -14,6 +14,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
     # https://github.com/docker/setup-qemu-action
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1

--- a/.github/workflows/protobuf-dockerimage.yml
+++ b/.github/workflows/protobuf-dockerimage.yml
@@ -48,6 +48,7 @@ jobs:
     - name: Build and push
       uses: docker/build-push-action@v2
       with:
+        context: .
         file: protobuf/Dockerfile
         platforms: linux/amd64,linux/arm64
         push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/protobuf-dockerimage.yml
+++ b/.github/workflows/protobuf-dockerimage.yml
@@ -52,7 +52,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: "{{defaultContext}}:protobuf"
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/protobuf/Dockerfile
+++ b/protobuf/Dockerfile
@@ -16,10 +16,12 @@ ARG PROTOC_GEN_PARQUET_VERSION=0.4.3
 ARG UPX_VERSION=3.96
 
 # Provided by docker buildx when running multi-arch builds via --platform flag
-ARG TARGETARCH=amd64
+ARG BUILDPLATFORM BUILDOS BUILDARCH
+ARG TARGETPLATFORM TARGETOS TARGETARCH
 
 FROM alpine:${ALPINE_VERSION} as protoc_builder
-RUN echo "Build arch: $TARGETARCH"
+RUN echo "Build platform: $BUILDPLATFORM - $BUILDOS/$BUILDARCH"
+RUN echo "Target platform: $TARGETPLATFORM - $TARGETOS/$TARGETARCH"
 RUN apk add --no-cache build-base curl automake autoconf libtool git zlib-dev linux-headers cmake ninja
 
 RUN mkdir -p /out

--- a/protobuf/Dockerfile
+++ b/protobuf/Dockerfile
@@ -15,13 +15,9 @@ ARG GRPC_GATEWAY_VERSION=2.6.0
 ARG PROTOC_GEN_PARQUET_VERSION=0.4.3
 ARG UPX_VERSION=3.96
 
-# Provided by docker buildx when running multi-arch builds via --platform flag
-ARG BUILDPLATFORM TARGETPLATFORM TARGETARCH=arm64
-
 FROM alpine:${ALPINE_VERSION} as protoc_builder
-
-ARG BUILDPLATFORM TARGETPLATFORM TARGETARCH
-RUN echo "Build args: $BUILDPLATFORM -- $TARGETPLATFORM -- $TARGETARCH"
+ARG TARGETPLATFORM
+RUN echo "I'm building for $TARGETPLATFORM"
 
 RUN apk add --no-cache build-base curl automake autoconf libtool git zlib-dev linux-headers cmake ninja
 

--- a/protobuf/Dockerfile
+++ b/protobuf/Dockerfile
@@ -15,6 +15,8 @@ ARG GRPC_GATEWAY_VERSION=2.6.0
 ARG PROTOC_GEN_PARQUET_VERSION=0.4.3
 ARG UPX_VERSION=3.96
 
+# Provided by docker buildx when running multi-arch builds via --platform flag
+ARG TARGETARCH=amd64
 
 FROM alpine:${ALPINE_VERSION} as protoc_builder
 RUN apk add --no-cache build-base curl automake autoconf libtool git zlib-dev linux-headers cmake ninja
@@ -36,7 +38,7 @@ RUN git clone --recursive --depth=1 -b v${GRPC_VERSION} https://github.com/grpc/
         ../.. && \
     cmake --build . --target plugins && \
     cmake --build . --target install && \
-    DESTDIR=/out cmake --build . --target install 
+    DESTDIR=/out cmake --build . --target install
 
 ARG PROTOBUF_C_VERSION
 RUN mkdir -p /protobuf-c && \
@@ -102,12 +104,12 @@ RUN mkdir -p ${GOPATH}/src/github.com/gogo/protobuf && \
     install -D $(find ./protobuf/google/protobuf -name '*.proto') -t /out/usr/include/github.com/gogo/protobuf/protobuf/google/protobuf && \
     install -D ./gogoproto/gogo.proto /out/usr/include/github.com/gogo/protobuf/gogoproto/gogo.proto
 
-ARG PROTOC_GEN_LINT_VERSION
+ARG PROTOC_GEN_LINT_VERSION TARGETARCH
 RUN cd / && \
-    curl -sSLO https://github.com/ckaznocha/protoc-gen-lint/releases/download/v${PROTOC_GEN_LINT_VERSION}/protoc-gen-lint_linux_amd64.zip && \
+    curl -sSLO https://github.com/ckaznocha/protoc-gen-lint/releases/download/v${PROTOC_GEN_LINT_VERSION}/protoc-gen-lint_linux_${TARGETARCH}.zip && \
     mkdir -p /protoc-gen-lint-out && \
     cd /protoc-gen-lint-out && \
-    unzip -q /protoc-gen-lint_linux_amd64.zip && \
+    unzip -q /protoc-gen-lint_linux_${TARGETARCH}.zip && \
     install -Ds /protoc-gen-lint-out/protoc-gen-lint /out/usr/bin/protoc-gen-lint
 
 ARG GRPC_GATEWAY_VERSION
@@ -133,8 +135,8 @@ RUN mkdir -p ${GOPATH}/src/github.com/atoulme/protoc-gen-parquet && \
 FROM alpine:${ALPINE_VERSION} as packer
 RUN apk add --no-cache curl
 
-ARG UPX_VERSION
-RUN mkdir -p /upx && curl -sSL https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-amd64_linux.tar.xz | tar xJ --strip 1 -C /upx && \
+ARG UPX_VERSION TARGETARCH
+RUN mkdir -p /upx && curl -sSL https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-${TARGETARCH}_linux.tar.xz | tar xJ --strip 1 -C /upx && \
     install -D /upx/upx /usr/local/bin/upx
 
 # Use all output including headers and protoc from protoc_builder

--- a/protobuf/Dockerfile
+++ b/protobuf/Dockerfile
@@ -16,15 +16,12 @@ ARG PROTOC_GEN_PARQUET_VERSION=0.4.3
 ARG UPX_VERSION=3.96
 
 # Provided by docker buildx when running multi-arch builds via --platform flag
-ARG BUILDPLATFORM BUILDOS BUILDARCH
-ARG TARGETPLATFORM TARGETOS TARGETARCH
+ARG BUILDPLATFORM TARGETPLATFORM TARGETARCH=arm64
 
 FROM alpine:${ALPINE_VERSION} as protoc_builder
 
-ARG BUILDPLATFORM
-RUN echo "Build platform $BUILDPLATFORM"
-ARG TARGETPLATFORM
-RUN echo "Target platform: $TARGETPLATFORM"
+ARG BUILDPLATFORM TARGETPLATFORM TARGETARCH
+RUN echo "Build args: $BUILDPLATFORM -- $TARGETPLATFORM -- $TARGETARCH"
 
 RUN apk add --no-cache build-base curl automake autoconf libtool git zlib-dev linux-headers cmake ninja
 

--- a/protobuf/Dockerfile
+++ b/protobuf/Dockerfile
@@ -20,8 +20,12 @@ ARG BUILDPLATFORM BUILDOS BUILDARCH
 ARG TARGETPLATFORM TARGETOS TARGETARCH
 
 FROM alpine:${ALPINE_VERSION} as protoc_builder
-RUN echo "Build platform: $BUILDPLATFORM - $BUILDOS/$BUILDARCH"
-RUN echo "Target platform: $TARGETPLATFORM - $TARGETOS/$TARGETARCH"
+
+ARG BUILDPLATFORM
+RUN echo "Build platform $BUILDPLATFORM"
+ARG TARGETPLATFORM
+RUN echo "Target platform: $TARGETPLATFORM"
+
 RUN apk add --no-cache build-base curl automake autoconf libtool git zlib-dev linux-headers cmake ninja
 
 RUN mkdir -p /out

--- a/protobuf/Dockerfile
+++ b/protobuf/Dockerfile
@@ -19,6 +19,7 @@ ARG UPX_VERSION=3.96
 ARG TARGETARCH=amd64
 
 FROM alpine:${ALPINE_VERSION} as protoc_builder
+RUN echo "Build arch: $TARGETARCH"
 RUN apk add --no-cache build-base curl automake autoconf libtool git zlib-dev linux-headers cmake ninja
 
 RUN mkdir -p /out


### PR DESCRIPTION
Updates the github workflow to use standard docker actions to build and publish multi-arch images when a git tag is pushed.

The workflow creates two tags, `latest` and one that is the git tag with the leading v stripped off. For example, the tag `v1.2.3` would create an image with tags `latest` and `1.2.3`.

- Closes #115
- Closes https://github.com/open-telemetry/opentelemetry-proto-go/issues/77