### PR TITLE
Make pylint work with python 3.11 and fix new errors

### DIFF
--- a/semantic-conventions/.pylintrc
+++ b/semantic-conventions/.pylintrc
@@ -1,7 +1,7 @@
 [MESSAGES CONTROL]
 # TODO: We should actually fix the warnings instead of disabling them
 #   except for the stuff up to fixme, which is fine to ignore / defer to black. 
-disable = bad-whitespace, wrong-import-order, wrong-hanging-indentation, line-too-long, missing-docstring, unused-import, fixme, invalid-name, too-many-instance-attributes, too-many-locals, too-many-statements, too-many-branches, too-many-arguments, too-many-public-methods, too-few-public-methods, protected-access
+disable = wrong-import-order, line-too-long, missing-docstring, unused-import, fixme, invalid-name, too-many-instance-attributes, too-many-locals, too-many-statements, too-many-branches, too-many-arguments, too-many-public-methods, too-few-public-methods, protected-access
 
 [FORMAT]
 good-names=e,ex

--- a/semantic-conventions/dev-requirements.txt
+++ b/semantic-conventions/dev-requirements.txt
@@ -2,5 +2,5 @@ black==22.3.0
 mypy==0.910
 pytest==6.2.5
 flake8==3.9.2
-pylint==2.10.2
+pylint==2.15.5
 isort==5.9.3

--- a/semantic-conventions/src/opentelemetry/semconv/main.py
+++ b/semantic-conventions/src/opentelemetry/semconv/main.py
@@ -33,7 +33,7 @@ def parse_semconv(args, parser) -> SemanticConventionSet:
     find_yaml(args)
     for file in sorted(args.files):
         if not file.endswith(".yaml") and not file.endswith(".yml"):
-            parser.error("{} is not a yaml file.".format(file))
+            parser.error(f"{file} is not a yaml file.")
         semconv.parse(file)
     semconv.finish()
     if semconv.has_error():
@@ -97,8 +97,8 @@ def find_yaml(args):
             exclude_file_list(args.yaml_root if args.yaml_root else "", args.exclude)
         )
         yaml_files = set(
-            glob.glob("{}/**/*.yaml".format(args.yaml_root), recursive=True)
-        ).union(set(glob.glob("{}/**/*.yml".format(args.yaml_root), recursive=True)))
+            glob.glob(f"{args.yaml_root}/**/*.yaml", recursive=True)
+        ).union(set(glob.glob(f"{args.yaml_root}/**/*.yml", recursive=True)))
         file_names = yaml_files - exclude
         args.files.extend(file_names)
 

--- a/semantic-conventions/src/opentelemetry/semconv/model/exceptions.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/exceptions.py
@@ -34,4 +34,4 @@ class ValidationError(Exception):
         self.column = column
 
     def __str__(self):
-        return "{} - @{}:{}".format(self.message, self.line, self.column)
+        return f"{self.message} - @{self.line}:{self.column}"

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
@@ -119,14 +119,14 @@ class SemanticAttribute:
                 validate_id(attr_id, position_data["id"])
                 attr_type, brief, examples = SemanticAttribute.parse_id(attribute)
                 if prefix:
-                    fqn = "{}.{}".format(prefix, attr_id)
+                    fqn = f"{prefix}.{attr_id}"
                 else:
                     fqn = attr_id
             else:
                 # Ref
                 attr_type = None
                 if "type" in attribute:
-                    msg = "Ref attribute '{}' must not declare a type".format(ref)
+                    msg = f"Ref attribute '{ref}' must not declare a type"
                     raise ValidationError.from_yaml_pos(position, msg)
                 brief = attribute.get("brief")
                 examples = attribute.get("examples")
@@ -164,9 +164,7 @@ class SemanticAttribute:
 
             if requirement_level_val and requirement_level is None:
                 position = position_data["requirement_level"]
-                msg = "Value '{}' for required field is not allowed".format(
-                    requirement_level_val
-                )
+                msg = f"Value '{requirement_level_val}' for required field is not allowed"
                 raise ValidationError.from_yaml_pos(position, msg)
 
             if (
@@ -190,9 +188,7 @@ class SemanticAttribute:
                     if "stability" in position_data
                     else position_data["deprecated"]
                 )
-                msg = "Semantic convention stability set to deprecated but attribute '{}' is {}".format(
-                    attr_id, stability
-                )
+                msg = f"Semantic convention stability set to deprecated but attribute '{attr_id}' is {stability}"
                 raise ValidationError.from_yaml_pos(position, msg)
             stability = stability or semconv_stability or StabilityLevel.STABLE
             sampling_relevant = (
@@ -259,7 +255,7 @@ class SemanticAttribute:
             and not isinstance(examples, CommentedSeq)
         ):
             position = attribute.lc.data[list(attribute)[0]]
-            msg = "Non array examples for {} are not allowed".format(attr_type)
+            msg = f"Non array examples for {attr_type} are not allowed"
             raise ValidationError.from_yaml_pos(position, msg)
         if not isinstance(examples, CommentedSeq) and examples is not None:
             # TODO: If validation fails later, this will crash when trying to access position data
@@ -275,7 +271,7 @@ class SemanticAttribute:
         ):
             if not examples:
                 position = attribute.lc.data[list(attribute)[0]]
-                msg = "Empty examples for {} are not allowed".format(attr_type)
+                msg = f"Empty examples for {attr_type} are not allowed"
                 raise ValidationError.from_yaml_pos(position, msg)
 
         # TODO: Implement type check for enum examples or forbid them
@@ -290,9 +286,7 @@ class SemanticAttribute:
         if deprecated is not None:
             if stability is not None and stability != "deprecated":
                 position = position_data["deprecated"]
-                msg = "There is a deprecation message but the stability is set to '{}'".format(
-                    stability
-                )
+                msg = "There is a deprecation message but the stability is set to '{stability}'"
                 raise ValidationError.from_yaml_pos(position, msg)
             if AttributeType.get_type(deprecated) != "string" or deprecated == "":
                 position = position_data["deprecated"]
@@ -322,7 +316,7 @@ class SemanticAttribute:
         val = stability_value_map.get(stability_value)
         if val is not None:
             return val
-        msg = "Value '{}' is not allowed as a stability marker".format(stability_value)
+        msg = f"Value '{stability_value}' is not allowed as a stability marker"
         raise ValidationError.from_yaml_pos(position, msg)
 
     def equivalent_to(self, other: "SemanticAttribute"):
@@ -387,16 +381,12 @@ class AttributeType:
                 for element in example:
                     if not isinstance(element, zlass):
                         position = examples.lc.data[index]
-                        msg = "Example with wrong type. Expected {} examples but is was {}.".format(
-                            attr_type, type(element)
-                        )
+                        msg = f"Example with wrong type. Expected {attr_type} examples but is was {type(element)}."
                         raise ValidationError.from_yaml_pos(position, msg)
             else:  # Single value example or array example with a single example array
                 if not isinstance(example, zlass):
                     position = examples.lc.data[index]
-                    msg = "Example with wrong type. Expected {} examples but is was {}.".format(
-                        attr_type, type(example)
-                    )
+                    msg = f"Example with wrong type. Expected {attr_type} examples but is was {type(example)}."
                     raise ValidationError.from_yaml_pos(position, msg)
 
     @staticmethod
@@ -411,7 +401,7 @@ class AttributeType:
             if AttributeType.bool_type_false.fullmatch(yaml_value):
                 return False
         position = parent_object.lc.data[key]
-        msg = "Value '{}' for {} field is not allowed".format(yaml_value, key)
+        msg = f"Value '{yaml_value}' for {key} field is not allowed"
         raise ValidationError.from_yaml_pos(position, msg)
 
 
@@ -444,7 +434,7 @@ class EnumAttributeType:
                 return attribute_type
             # Wrong type used - raise the exception and fill the missing data in the parent
             raise ValidationError(
-                0, 0, "Invalid type: {} is not allowed".format(attribute_type)
+                0, 0, f"Invalid type: {attribute_type} is not allowed"
             )
         allowed_keys = ["allow_custom_values", "members"]
         mandatory_keys = ["members"]
@@ -470,7 +460,7 @@ class EnumAttributeType:
             if not EnumAttributeType.is_valid_enum_value(member["value"]):
                 raise ValidationError.from_yaml_pos(
                     member.lc.data["value"][:2],
-                    "Invalid value used in enum: <{}>".format(member["value"]),
+                    f"Invalid value used in enum: <{member['value']}>",
                 )
             validate_id(member["id"], member.lc.data["id"])
             members.append(
@@ -486,7 +476,7 @@ class EnumAttributeType:
             if enum_type != AttributeType.get_type(m.value):
                 raise ValidationError.from_yaml_pos(
                     myaml.lc.data["value"],
-                    "Enumeration member does not have type {}!".format(enum_type),
+                    f"Enumeration member does not have type {enum_type}!",
                 )
         return EnumAttributeType(custom_values, members, enum_type)
 
@@ -508,7 +498,7 @@ class MdLink:
         self.url = url
 
     def __str__(self):
-        return "[{}]({})".format(self.text, self.url)
+        return f"[{self.text}]({self.url})"
 
 
 class TextWithLinks(str):

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
@@ -164,7 +164,9 @@ class SemanticAttribute:
 
             if requirement_level_val and requirement_level is None:
                 position = position_data["requirement_level"]
-                msg = f"Value '{requirement_level_val}' for required field is not allowed"
+                msg = (
+                    f"Value '{requirement_level_val}' for required field is not allowed"
+                )
                 raise ValidationError.from_yaml_pos(position, msg)
 
             if (
@@ -286,7 +288,7 @@ class SemanticAttribute:
         if deprecated is not None:
             if stability is not None and stability != "deprecated":
                 position = position_data["deprecated"]
-                msg = "There is a deprecation message but the stability is set to '{stability}'"
+                msg = f"There is a deprecation message but the stability is set to '{stability}'"
                 raise ValidationError.from_yaml_pos(position, msg)
             if AttributeType.get_type(deprecated) != "string" or deprecated == "":
                 position = position_data["deprecated"]

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -266,7 +266,10 @@ class SemanticConventionSet:
                     if model.semconv_id in self.models:
                         self.errors = True
                         print(f"Error parsing {file}\n", file=sys.stderr)
-                        print(f"Semantic convention '{model.semconv_id}' is already defined.", file=sys.stderr)
+                        print(
+                            f"Semantic convention '{model.semconv_id}' is already defined.",
+                            file=sys.stderr,
+                        )
                     self.models[model.semconv_id] = model
             except ValidationError as e:
                 self.errors = True
@@ -475,7 +478,9 @@ class SemanticConventionSet:
                 for attr in include_semconv.attributes:
                     if semconv.contains_attribute(attr):
                         if self.debug:
-                            print("[Includes] {semconv.semconv_id} already contains attribute {attr}")
+                            print(
+                                f"[Includes] {semconv.semconv_id} already contains attribute {attr}"
+                            )
                         continue
                     # There are changes
                     fixpoint_inc = False

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -74,16 +74,14 @@ def SemanticConvention(group):
         line = group.lc.data["id"][0] + 1
         doc_url = "https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups"
         print(
-            "Please set the type for group '{}' on line {} - defaulting to type 'span'. See {}".format(
-                group["id"], line, doc_url
-            ),
+            f"Please set the type for group '{group['id']}' on line {line} - defaulting to type 'span'. See {doc_url}",
             file=sys.stderr,
         )
 
     convention_type = parse_semantic_convention_type(type_value)
     if convention_type is None:
         position = group.lc.data["type"] if "type" in group else group.lc.data["id"]
-        msg = "Invalid value for semantic convention type: {}".format(group.get("type"))
+        msg = f"Invalid value for semantic convention type: {group.get('type')}"
         raise ValidationError.from_yaml_pos(position, msg)
 
     # First, validate that the correct fields are available in the yaml
@@ -211,7 +209,7 @@ class SpanSemanticConvention(BaseSemanticConvention):
         self.span_kind = SpanKind.parse(group.get("span_kind"))
         if self.span_kind is None:
             position = group.lc.data["span_kind"]
-            msg = "Invalid value for span_kind: {}".format(group.get("span_kind"))
+            msg = f"Invalid value for span_kind: {group.get('span_kind')}"
             raise ValidationError.from_yaml_pos(position, msg)
 
 
@@ -267,17 +265,12 @@ class SemanticConventionSet:
                 for model in semconv_models:
                     if model.semconv_id in self.models:
                         self.errors = True
-                        print("Error parsing {}\n".format(file), file=sys.stderr)
-                        print(
-                            "Semantic convention '{}' is already defined.".format(
-                                model.semconv_id
-                            ),
-                            file=sys.stderr,
-                        )
+                        print(f"Error parsing {file}\n", file=sys.stderr)
+                        print(f"Semantic convention '{model.semconv_id}' is already defined.", file=sys.stderr)
                     self.models[model.semconv_id] = model
             except ValidationError as e:
                 self.errors = True
-                print("Error parsing {}\n".format(file), file=sys.stderr)
+                print(f"Error parsing {file}\n", file=sys.stderr)
                 print(e, file=sys.stderr)
 
     def has_error(self):
@@ -291,9 +284,7 @@ class SemanticConventionSet:
                     if attr.fqn in group_by_fqn:
                         self.errors = True
                         print(
-                            "Attribute {} of Semantic convention '{}' is already defined in {}.".format(
-                                attr.fqn, model.semconv_id, group_by_fqn.get(attr.fqn)
-                            ),
+                            f"Attribute {attr.fqn} of Semantic convention '{model.semconv_id}' is already defined in {group_by_fqn.get(attr.fqn)}.",
                             file=sys.stderr,
                         )
                     group_by_fqn[attr.fqn] = model.semconv_id
@@ -351,9 +342,7 @@ class SemanticConventionSet:
             if extended is None:
                 raise ValidationError.from_yaml_pos(
                     semconv._position,
-                    "Semantic Convention {} extends {} but the latter cannot be found!".format(
-                        semconv.semconv_id, semconv.extends
-                    ),
+                    f"Semantic Convention {semconv.semconv_id} extends {semconv.extends} but the latter cannot be found!",
                 )
 
             # Process hierarchy chain
@@ -415,9 +404,7 @@ class SemanticConventionSet:
                         if ref_attr is None:
                             raise ValidationError.from_yaml_pos(
                                 any_of._yaml_src_position[index],
-                                "Any_of attribute '{}' of semantic convention {} does not exists!".format(
-                                    attr_id, semconv.semconv_id
-                                ),
+                                f"Any_of attribute '{attr_id}' of semantic convention {semconv.semconv_id} does not exists!",
                             )
                         constraint_attrs.append(ref_attr)
                     if constraint_attrs:
@@ -431,17 +418,13 @@ class SemanticConventionSet:
                 if event is None:
                     raise ValidationError.from_yaml_pos(
                         semconv._position,
-                        "Semantic Convention {} has {} as event but the latter cannot be found!".format(
-                            semconv.semconv_id, event_id
-                        ),
+                        f"Semantic Convention {semconv.semconv_id} has {event_id} as event but the latter cannot be found!",
                     )
                 if not isinstance(event, EventSemanticConvention):
                     raise ValidationError.from_yaml_pos(
                         semconv._position,
-                        "Semantic Convention {} has {} as event but"
-                        " the latter is not a semantic convention for events!".format(
-                            semconv.semconv_id, event_id
-                        ),
+                        f"Semantic Convention {semconv.semconv_id} has {event_id} as event but"
+                        " the latter is not a semantic convention for events!",
                     )
                 events.append(event)
             semconv.events = events
@@ -457,9 +440,7 @@ class SemanticConventionSet:
                 if not ref_attr:
                     raise ValidationError.from_yaml_pos(
                         semconv._position,
-                        "Semantic Convention {} reference `{}` but it cannot be found!".format(
-                            semconv.semconv_id, attr.ref
-                        ),
+                        f"Semantic Convention {semconv.semconv_id} reference `{attr.ref}` but it cannot be found!",
                     )
                 attr.attr_type = ref_attr.attr_type
                 if not attr.brief:
@@ -484,9 +465,7 @@ class SemanticConventionSet:
                 if include_semconv is None:
                     raise ValidationError.from_yaml_pos(
                         semconv._position,
-                        "Semantic Convention {} includes {} but the latter cannot be found!".format(
-                            semconv.semconv_id, constraint.semconv_id
-                        ),
+                        f"Semantic Convention {semconv.semconv_id} includes {constraint.semconv_id} but the latter cannot be found!",
                     )
                 # We resolve the parent/child relationship of the included semantic convention, if any
                 self._populate_extends_single(
@@ -496,11 +475,7 @@ class SemanticConventionSet:
                 for attr in include_semconv.attributes:
                     if semconv.contains_attribute(attr):
                         if self.debug:
-                            print(
-                                "[Includes] {} already contains attribute {}".format(
-                                    semconv.semconv_id, attr
-                                )
-                            )
+                            print("[Includes] {semconv.semconv_id} already contains attribute {attr}")
                         continue
                     # There are changes
                     fixpoint_inc = False

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -287,7 +287,8 @@ class SemanticConventionSet:
                     if attr.fqn in group_by_fqn:
                         self.errors = True
                         print(
-                            f"Attribute {attr.fqn} of Semantic convention '{model.semconv_id}' is already defined in {group_by_fqn.get(attr.fqn)}.",
+                            f"Attribute {attr.fqn} of Semantic convention '{model.semconv_id}'"
+                            "is already defined in {group_by_fqn.get(attr.fqn)}.",
                             file=sys.stderr,
                         )
                     group_by_fqn[attr.fqn] = model.semconv_id
@@ -345,7 +346,8 @@ class SemanticConventionSet:
             if extended is None:
                 raise ValidationError.from_yaml_pos(
                     semconv._position,
-                    f"Semantic Convention {semconv.semconv_id} extends {semconv.extends} but the latter cannot be found!",
+                    f"Semantic Convention {semconv.semconv_id} extends "
+                    "{semconv.extends} but the latter cannot be found!",
                 )
 
             # Process hierarchy chain
@@ -407,7 +409,8 @@ class SemanticConventionSet:
                         if ref_attr is None:
                             raise ValidationError.from_yaml_pos(
                                 any_of._yaml_src_position[index],
-                                f"Any_of attribute '{attr_id}' of semantic convention {semconv.semconv_id} does not exists!",
+                                f"Any_of attribute '{attr_id}' of semantic convention "
+                                "{semconv.semconv_id} does not exists!",
                             )
                         constraint_attrs.append(ref_attr)
                     if constraint_attrs:
@@ -421,7 +424,8 @@ class SemanticConventionSet:
                 if event is None:
                     raise ValidationError.from_yaml_pos(
                         semconv._position,
-                        f"Semantic Convention {semconv.semconv_id} has {event_id} as event but the latter cannot be found!",
+                        f"Semantic Convention {semconv.semconv_id} has "
+                        "{event_id} as event but the latter cannot be found!",
                     )
                 if not isinstance(event, EventSemanticConvention):
                     raise ValidationError.from_yaml_pos(
@@ -468,7 +472,8 @@ class SemanticConventionSet:
                 if include_semconv is None:
                     raise ValidationError.from_yaml_pos(
                         semconv._position,
-                        f"Semantic Convention {semconv.semconv_id} includes {constraint.semconv_id} but the latter cannot be found!",
+                        f"Semantic Convention {semconv.semconv_id} includes "
+                        "{constraint.semconv_id} but the latter cannot be found!",
                     )
                 # We resolve the parent/child relationship of the included semantic convention, if any
                 self._populate_extends_single(

--- a/semantic-conventions/src/opentelemetry/semconv/model/utils.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/utils.py
@@ -27,9 +27,7 @@ def validate_id(semconv_id, position):
     if not ID_RE.fullmatch(semconv_id):
         raise ValidationError.from_yaml_pos(
             position,
-            "Invalid id {}. Semantic Convention ids MUST match {}".format(
-                semconv_id, ID_RE.pattern
-            ),
+            f"Invalid id {semconv_id}. Semantic Convention ids MUST match {ID_RE.pattern}",
         )
 
 
@@ -38,7 +36,7 @@ def validate_values(yaml, keys, mandatory=()):
     unwanted = [k for k in yaml.keys() if k not in keys]
     if unwanted:
         position = yaml.lc.data[unwanted[0]]
-        msg = "Invalid keys: {}".format(unwanted)
+        msg = f"Invalid keys: {unwanted}"
         raise ValidationError.from_yaml_pos(position, msg)
     if mandatory:
         check_no_missing_keys(yaml, mandatory)
@@ -48,7 +46,7 @@ def check_no_missing_keys(yaml, mandatory):
     missing = list(set(mandatory) - set(yaml))
     if missing:
         position = (yaml.lc.line, yaml.lc.col)
-        msg = "Missing keys: {}".format(missing)
+        msg = f"Missing keys: {missing}"
         raise ValidationError.from_yaml_pos(position, msg)
 
 
@@ -68,7 +66,7 @@ class ValidatableYamlNode:
         unwanted = [key for key in node.keys() if key not in cls.allowed_keys]
         if unwanted:
             position = node.lc.data[unwanted[0]]
-            msg = "Invalid keys: {}".format(unwanted)
+            msg = f"Invalid keys: {unwanted}"
             raise ValidationError.from_yaml_pos(position, msg)
 
         if cls.mandatory_keys:

--- a/semantic-conventions/src/opentelemetry/semconv/templating/code.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/code.py
@@ -127,7 +127,7 @@ def to_html_links(doc_string: typing.Optional[typing.Union[str, TextWithLinks]])
             if isinstance(elm, str):
                 str_list.append(elm)
             else:
-                str_list.append('<a href="{}">{}</a>'.format(elm.url, elm.text))
+                str_list.append(f'<a href="{elm.url}">{elm.text}</a>')
         doc_string = "".join(str_list)
     doc_string = doc_string.strip()
     if doc_string.endswith("."):
@@ -157,7 +157,7 @@ def to_camelcase(name: str, first_upper=False) -> str:
 
 
 class CodeRenderer:
-    pattern = "{{{}}}".format(ID_RE.pattern)
+    pattern = f"{{{ID_RE.pattern}}}"
     matcher = re.compile(pattern)
 
     parameters: typing.Dict[str, str]

--- a/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
@@ -121,7 +121,7 @@ class MarkdownRenderer:
         description += attribute.brief
         if attribute.note:
             self.render_ctx.add_note(attribute.note)
-            description += f" [{self.render_ctx.notes}]"
+            description += f" [{len(self.render_ctx.notes)}]"
         examples = ""
         if isinstance(attribute.attr_type, EnumAttributeType):
             if self.render_ctx.is_full or (attribute.is_local and not attribute.ref):
@@ -141,9 +141,7 @@ class MarkdownRenderer:
             example_list = attribute.examples if attribute.examples else []
             # check for array types
             if attribute.attr_type.endswith("[]"):
-                examples = (
-                    "`[" + ", ".join(f"{ex}" for ex in example_list) + "]`"
-                )
+                examples = "`[" + ", ".join(f"{ex}" for ex in example_list) + "]`"
             else:
                 examples = "; ".join(f"`{ex}`" for ex in example_list)
         if attribute.requirement_level == RequirementLevel.REQUIRED:
@@ -228,9 +226,7 @@ class MarkdownRenderer:
             "| ------------| ----------------         | -----------   |"
         )
         for member in members.values():
-            output.write(
-                f"\n| {member.id} | {member.brief} | `{member.value}` |"
-            )
+            output.write(f"\n| {member.id} | {member.brief} | `{member.value}` |")
         output.write("\n")
 
     def to_markdown_enum(self, output: io.StringIO):
@@ -295,9 +291,7 @@ class MarkdownRenderer:
         if isinstance(obj, AnyOf):
             self.to_markdown_anyof(obj, output)
         elif not isinstance(obj, Include):
-            raise Exception(
-                f"Trying to generate Markdown for a wrong type {type(obj)}"
-            )
+            raise Exception(f"Trying to generate Markdown for a wrong type {type(obj)}")
 
     def render_md(self):
         for md_filename in self.file_names:
@@ -394,9 +388,7 @@ class MarkdownRenderer:
             if not semconv:
                 # We should not fail here since we would detect this earlier
                 # But better be safe than sorry
-                raise ValueError(
-                    f"Semantic Convention ID {semconv_id} not found"
-                )
+                raise ValueError(f"Semantic Convention ID {semconv_id} not found")
             output.write(content[last_match : match.start(0)])
             self._render_group(semconv, parameters, output)
             end_match = self.p_end.search(content, last_match)

--- a/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
+++ b/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
@@ -296,7 +296,7 @@ class TestCorrectParse(unittest.TestCase):
         s = list(semconv.models.values())[0]
         for attr in s.attributes:
             brief = attr.brief
-            self.assertEqual(brief.raw_text, brief.__str__())
+            self.assertEqual(brief.raw_text, str(brief))
 
     # This fails until ONE-36916 is not addressed
     def test_ref(self):


### PR DESCRIPTION
Build scripts now use Python 3.11, but old pylint does not work with it:

https://github.com/open-telemetry/build-tools/actions/runs/3439733856/jobs/5737365717

This change updates pylint and also fixes new errors from it.