### PR TITLE
Add multiarch Docker images

### DIFF
--- a/.github/workflows/protobuf-dockerimage.yml
+++ b/.github/workflows/protobuf-dockerimage.yml
@@ -1,41 +1,133 @@
 name: Protobuf Docker Image
 on:
   push:
-    tags: [ '**' ]
-    branches: [ main ]
+    tags:
+      - "**"
+    branches:
+      - main
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - .github/workflows/protobuf-dockerimage.yml
       - protobuf/Dockerfile
       - protobuf/protoc-wrapper
 
+env:
+  DOCKERHUB_SLUG: otel/build-protobuf
+
 jobs:
   build:
-    strategy:
-      matrix:
-        TARGETARCH: [amd64]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
-    - uses: actions/checkout@v4
-    - name: Build the Docker image
-      run: docker build protobuf/. -t build-protobuf
-      env:
-        TARGETARCH: ${{ matrix.TARGETARCH }}
-    - name: Push the Docker image
-      if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
-      run: |
-        echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-        function tag_and_push {
-          docker tag build-protobuf "otel/build-protobuf:${1}" && docker push "otel/build-protobuf:${1}"
-        }
-        if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
-          tag_and_push "latest"
-        elif [[ "${GITHUB_REF}" =~ refs/tags/v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            TAG="${GITHUB_REF#"refs/tags/v"}"
-            tag_and_push "${TAG}"
-        else
-          tag_and_push "${GITHUB_REF#"refs/tags/"}"
-        fi
-      env:
-        TARGETARCH: ${{ matrix.TARGETARCH }}
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            name=${{ env.DOCKERHUB_SLUG}}
+          tags: |
+            type=edge
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
+
+      - name: DockerHub Login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+        if: github.event_name != 'pull_request'
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: "protobuf/."
+          cache-from: type=gha,scope=protobuf-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,scope=protobuf-${{ env.PLATFORM_PAIR }},mode=max
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          pull: true
+          sbom: true
+          provenance: mode=max
+          outputs: type=image,name=${{ env.DOCKERHUB_SLUG }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+
+  merge:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    needs:
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            name=${{ env.DOCKERHUB_SLUG}}
+          tags: |
+            type=edge
+            type=semver,pattern={{version}}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.DOCKERHUB_SLUG }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.DOCKERHUB_SLUG }}:${{ steps.meta.outputs.version }}

--- a/protobuf/Dockerfile
+++ b/protobuf/Dockerfile
@@ -1,19 +1,17 @@
 # gRPC core version that applies to C++, C#, Objective-C, PhP, Python, Ruby
-ARG GRPC_VERSION=1.52.0
-ARG PROTOBUF_C_VERSION=1.4.1
+ARG GRPC_VERSION=1.52.2
+ARG PROTOBUF_C_VERSION=1.5.0
 ARG GRPC_WEB_VERSION=1.3.0
 
-ARG PROTOC_GEN_GO_VERSION=1.5.2
-ARG PROTOC_GEN_GO_GRPC_VERSION=1.41.0
-ARG GRPC_JAVA_VERSION=1.51.3
-# v1.3.2, using the version directly does not work: "tar: invalid magic"
-ARG PROTOC_GEN_GOGO_VERSION=b03c65ea87cdc3521ede29f62fe3ce239267c1bc
+ARG PROTOC_GEN_GO_VERSION=1.32.0
+ARG PROTOC_GEN_GO_GRPC_VERSION=1.52.3
+ARG GRPC_JAVA_VERSION=1.52.1
+# use the lastest commit from master
+ARG PROTOC_GEN_GOGO_VERSION=f67b8970b736e53dbd7d0a27146c8f1ac52f74e5
 ARG PROTOC_GEN_LINT_VERSION=0.3.0
-ARG GRPC_GATEWAY_VERSION=2.15.0
+ARG GRPC_GATEWAY_VERSION=2.19.1
 ARG PROTOC_GEN_PARQUET_VERSION=0.4.3
-ARG UPX_VERSION=4.0.2
-
-ARG TARGETARCH=amd64
+ARG UPX_VERSION=4.2.2
 
 FROM alpine:3.18 as protoc_builder
 RUN apk add --no-cache build-base curl automake autoconf libtool git zlib-dev linux-headers cmake ninja
@@ -55,7 +53,7 @@ RUN mkdir -p /grpc-java && \
     -I. -I/usr/include \
     compiler/src/java_plugin/cpp/*.cpp \
     -L/usr/lib64 \
-    -lprotoc -lprotobuf -lpthread --std=c++0x -s \
+    -lprotoc -lprotobuf -lpthread -s \
     -o protoc-gen-grpc-java && \
     install -Ds protoc-gen-grpc-java /out/usr/bin/protoc-gen-grpc-java && \
     rm -Rf /grpc-java && \
@@ -68,7 +66,7 @@ RUN mkdir -p /grpc-web && \
     make install-plugin && \
     install -Ds /usr/local/bin/protoc-gen-grpc-web /out/usr/bin/protoc-gen-grpc-web
 
-FROM golang:1.18-alpine3.14 as go_builder
+FROM golang:1.22-alpine as go_builder
 RUN apk add --no-cache build-base curl git
 
 ARG PROTOC_GEN_GO_GRPC_VERSION
@@ -79,10 +77,10 @@ RUN mkdir -p ${GOPATH}/src/github.com/grpc/grpc-go && \
     install -Ds /golang-protobuf-out/protoc-gen-go-grpc /out/usr/bin/protoc-gen-go-grpc
 
 ARG PROTOC_GEN_GO_VERSION
-RUN mkdir -p ${GOPATH}/src/github.com/golang/protobuf && \
-    curl -sSL https://api.github.com/repos/golang/protobuf/tarball/v${PROTOC_GEN_GO_VERSION} | tar xz --strip 1 -C ${GOPATH}/src/github.com/golang/protobuf &&\
-    cd ${GOPATH}/src/github.com/golang/protobuf && \
-    go build -ldflags '-w -s' -o /golang-protobuf-out/protoc-gen-go ./protoc-gen-go && \
+RUN mkdir -p ${GOPATH}/src/github.com/protocolbuffers/protobuf-go && \
+    curl -sSL https://api.github.com/repos/protocolbuffers/protobuf-go/tarball/v${PROTOC_GEN_GO_VERSION} | tar xz --strip 1 -C ${GOPATH}/src/github.com/protocolbuffers/protobuf-go &&\
+    cd ${GOPATH}/src/github.com/protocolbuffers/protobuf-go && \
+    go build -ldflags '-w -s' -o /golang-protobuf-out/protoc-gen-go ./cmd/protoc-gen-go && \
     install -Ds /golang-protobuf-out/protoc-gen-go /out/usr/bin/protoc-gen-go
 
 ARG PROTOC_GEN_GOGO_VERSION
@@ -108,7 +106,7 @@ RUN cd / && \
     mkdir -p /protoc-gen-lint-out && \
     cd /protoc-gen-lint-out && \
     unzip -q /protoc-gen-lint_linux_${TARGETARCH}.zip && \
-    install -Ds /protoc-gen-lint-out/protoc-gen-lint /out/usr/bin/protoc-gen-lint
+    install -D /protoc-gen-lint-out/protoc-gen-lint /out/usr/bin/protoc-gen-lint
 
 ARG GRPC_GATEWAY_VERSION
 RUN mkdir -p ${GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway && \


### PR DESCRIPTION
Use Docker actions and metadata-action to build the image for `linux/arm, linux/arm64, linux/amd64`.

Right now it will use `edge` as tag for the latest commit on `main` instead of `latest` (that's also the default for the action). And `latest` for the latest tag.
That's what I've seen in all the projects I've used. Let me know if that works.

Supersedes:

-  #116 
-  #73
- #99


Closes:


- Closes #115
- Closes https://github.com/open-telemetry/opentelemetry-proto-go/issues/77