### PR TITLE
Move footnotes back together with the rendered table in Markdown

### DIFF
--- a/semantic-conventions/CHANGELOG.md
+++ b/semantic-conventions/CHANGELOG.md
@@ -4,6 +4,11 @@ Please update the changelog as part of any significant pull request.
 
 ## Unreleased
 
+## v0.15.1
+
+- Move footnotes back together with the rendered table in Markdown
+  ([#131](https://github.com/open-telemetry/build-tools/pull/131))
+
 ## v0.15.0
 
 - Add a semantic convention type for Metrics ("metric" and "metric_group") 

--- a/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
@@ -203,11 +203,11 @@ class MarkdownRenderer:
         attr_sampling_relevant = [
             attr for attr in attr_to_print if attr.sampling_relevant
         ]
+        self.to_markdown_notes(output)
         self.to_creation_time_attributes(attr_sampling_relevant, output)
 
-    @staticmethod
     def to_markdown_metric_table(
-        semconv: MetricSemanticConvention, output: io.StringIO
+        self, semconv: MetricSemanticConvention, output: io.StringIO
     ):
         """
         This method renders metrics as markdown table entry
@@ -227,6 +227,7 @@ class MarkdownRenderer:
         output.write(
             f"| `{semconv.metric_name}` | {instrument} | `{semconv.unit}` | {semconv.brief} |\n"
         )
+        self.to_markdown_notes(output)
 
     def to_markdown_anyof(self, anyof: AnyOf, output: io.StringIO):
         """
@@ -473,7 +474,6 @@ class MarkdownRenderer:
                 output.write(f"The event name MUST be `{semconv.name}`.\n\n")
             self.to_markdown_attribute_table(semconv, output)
 
-        self.to_markdown_notes(output)
         if not self.render_ctx.is_remove_constraint:
             for cnst in semconv.constraints:
                 self.to_markdown_constraint(cnst, output)

--- a/semantic-conventions/src/tests/data/markdown/sampling_relevant/expected.md
+++ b/semantic-conventions/src/tests/data/markdown/sampling_relevant/expected.md
@@ -4,7 +4,7 @@
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.method` | string | . | `GET` | Required |
-| `http.url` | string | . | `.` | Recommended |
+| `http.url` | string | . [1] | `.` | Recommended |
 | `http.target` | string | . | `.` | Recommended |
 | `http.host` | string | . | `.` | Recommended |
 | `http.scheme` | string | . | `http` | Recommended |
@@ -13,6 +13,8 @@
 | [`net.peer.ip`](span-general.md) | string | . | `.` | Recommended |
 | [`net.peer.name`](span-general.md) | string | . | `.` | Recommended |
 | [`net.peer.port`](span-general.md) | int | . |  | Recommended |
+
+**[1]:** `http.url` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case the attribute's value should be `https://www.example.com/`.
 
 Following attributes MUST be provided **at span creation time** (when provided at all), so they can be considered for sampling decisions:
 

--- a/semantic-conventions/src/tests/data/markdown/sampling_relevant/http.yaml
+++ b/semantic-conventions/src/tests/data/markdown/sampling_relevant/http.yaml
@@ -12,6 +12,9 @@ groups:
       - id: url
         type: string
         brief: .
+        note: >
+          `http.url` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`.
+          In such case the attribute's value should be `https://www.example.com/`.
         sampling_relevant: true
         examples: ['.']
       - id: target


### PR DESCRIPTION
When trying to integrate the new tooling for metrics with the spec repo I noticed that #79 accidentally introduced a breaking change in markdown rendering.
It would move the footnotes belonging to attribute tables apart from them. https://github.com/open-telemetry/build-tools/releases/tag/v0.15.0 first prints the list defining sampling relevant attributes and only then prints the footnotes.