### PR TITLE
Support reading additional files with references

### DIFF
--- a/semantic-conventions/src/opentelemetry/semconv/main.py
+++ b/semantic-conventions/src/opentelemetry/semconv/main.py
@@ -37,7 +37,11 @@ def parse_semconv(args, parser) -> SemanticConventionSet:
         semconv.parse(file)
 
     if args.reference_only is not None:
-        reference_files = [f for f in glob_file_list(args.yaml_root, args.reference_only) if is_yaml_file(f)]
+        reference_files = [
+            f
+            for f in glob_file_list(args.yaml_root, args.reference_only)
+            if is_yaml_file(f)
+        ]
         for file in sorted(reference_files):
             semconv.parse(file, True)
 
@@ -46,8 +50,10 @@ def parse_semconv(args, parser) -> SemanticConventionSet:
         sys.exit(1)
     return semconv
 
+
 def is_yaml_file(file: str) -> bool:
     return file.endswith(".yaml") or file.endswith(".yml")
+
 
 def glob_file_list(folder: str, pattern: str) -> List[str]:
     if not pattern:
@@ -105,9 +111,11 @@ def find_yaml(args):
             glob_file_list(args.yaml_root if args.yaml_root else "", args.exclude)
         )
         reference_only = set(
-            glob_file_list(args.yaml_root if args.yaml_root else "", args.reference_only)
+            glob_file_list(
+                args.yaml_root if args.yaml_root else "", args.reference_only
+            )
         )
-        exclude.update(reference_only) 
+        exclude.update(reference_only)
 
         yaml_files = set(
             glob.glob(f"{args.yaml_root}/**/*.yaml", recursive=True)
@@ -237,7 +245,10 @@ def setup_parser():
         "--exclude", "-e", help="Exclude the matching files using GLOB syntax", type=str
     )
     parser.add_argument(
-        "--reference-only", "-r", help="Additional files to resolve references only (and extends) using GLOB syntax", type=str
+        "--reference-only",
+        "-r",
+        help="Additional files to resolve references only (and extends) using GLOB syntax",
+        type=str,
     )
     parser.add_argument(
         "files",

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -300,7 +300,9 @@ class SemanticConventionSet:
 
     debug: bool
     models: typing.Dict[str, BaseSemanticConvention] = field(default_factory=dict)
-    extended_models: typing.Dict[str, BaseSemanticConvention] = field(default_factory=dict)
+    extended_models: typing.Dict[str, BaseSemanticConvention] = field(
+        default_factory=dict
+    )
     errors: bool = False
 
     def parse(self, file, ref_only=False):

--- a/semantic-conventions/src/opentelemetry/semconv/templating/code.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/code.py
@@ -244,6 +244,7 @@ class CodeRenderer:
                 template.stream(data).dump(output_name)
         else:
             data = self.get_data_single_file(semconvset, template_path)
+            print (data)
             template = env.get_template(file_name, globals=data)
             template.globals["now"] = datetime.datetime.utcnow()
             template.globals["version"] = os.environ.get("ARTIFACT_VERSION", "dev")

--- a/semantic-conventions/src/opentelemetry/semconv/templating/code.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/code.py
@@ -244,7 +244,6 @@ class CodeRenderer:
                 template.stream(data).dump(output_name)
         else:
             data = self.get_data_single_file(semconvset, template_path)
-            print (data)
             template = env.get_template(file_name, globals=data)
             template.globals["now"] = datetime.datetime.utcnow()
             template.globals["version"] = os.environ.get("ARTIFACT_VERSION", "dev")

--- a/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
+++ b/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
@@ -735,7 +735,7 @@ class TestCorrectParse(unittest.TestCase):
         semconv.finish()
 
         self.assertEqual(len(semconv.models), 3)
-        
+
     def test_reference_only_extends(self):
         semconv = SemanticConventionSet(debug=False)
         semconv.parse(self.load_file("yaml/extends/child.http.yaml"))
@@ -750,9 +750,7 @@ class TestCorrectParse(unittest.TestCase):
             "prefix": "child.http",
             "extends": "http.server",
             "n_constraints": 1,
-            "attributes": [
-                "http.server_name",
-            ],
+            "attributes": ["http.server_name"],
         }
         self.semantic_convention_check(list(semconv.models.values())[0], expected)
 


### PR DESCRIPTION
Fixes #155

Adds `--references-only` flag to `semconvgen` which allows to specify additional sources for referenced (extended, included) semconv.

E.g. browser resource semconv references general `user_agent.original` attribute. When code for resources is generated, `user_agent.original` needs to be resolved, even though `user_agent` semconv is not generated.

Usage (tested on Java):

[All semconv except resources](https://github.com/open-telemetry/opentelemetry-java/blob/328dcf075a827ebe710274d020baafb978091b01/buildscripts/semantic-convention/generate.sh#L24-36)

```diff
docker run --rm \
  -v ${SCRIPT_DIR}/opentelemetry-specification/semantic_conventions:/source \
  -v ${SCRIPT_DIR}/templates:/templates \
  -v ${ROOT_DIR}/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/:/output \
  otel/semconvgen:$GENERATOR_VERSION \
-  --exclude resource/** \
+  --reference-only resource/** \
  -f /source code \
 ...
```
 New flag excludes semconvs from the output, but allows references to them.

Resources:

```diff
docker run --rm \
- -v ${SCRIPT_DIR}/opentelemetry-specification/semantic_conventions/resource/:/source \
+ -v ${SCRIPT_DIR}/opentelemetry-specification/semantic_conventions:/source \
  -v ${SCRIPT_DIR}/templates:/templates \
  -v ${ROOT_DIR}/semconv/src/main/java/io/opentelemetry/semconv/resource/attributes/:/output \
  semconvgen:$GENERATOR_VERSION \
+ --only resources \
+ --reference-only *.yaml \
  -f /source code \
....
```

I.e. from all semconv output resource conventions, and use yaml files from root folder `semantic_conventions` to resolve references.