### PR TITLE
Allow multiple semconv in --only flag

### DIFF
--- a/semantic-conventions/src/opentelemetry/semconv/main.py
+++ b/semantic-conventions/src/opentelemetry/semconv/main.py
@@ -59,12 +59,13 @@ def filter_semconv(semconv, types):
             if model.GROUP_TYPE_NAME in types
         }
 
+
 def main():
     parser = setup_parser()
     args = parser.parse_args()
     check_args(args, parser)
-    semconv_filter = parse_only_filter(args, parser)
     semconv = parse_semconv(args, parser)
+    semconv_filter = parse_only_filter(args, parser)
     filter_semconv(semconv, semconv_filter)
     if len(semconv.models) == 0:
         parser.error("No semantic convention model found!")
@@ -113,10 +114,12 @@ def parse_only_filter(arguments, parser):
     if not arguments.only:
         return None
 
-    types = [t.strip() for t in arguments.only.split(",")]        
+    types = [t.strip() for t in arguments.only.split(",")]
     unknown_types = [t for t in types if t not in CONVENTION_CLS_BY_GROUP_TYPE.keys()]
     if unknown_types:
-        parser.error(f"Unknown semconv names in `--only` option: '{', '.join(unknown_types)}'")
+        parser.error(
+            f"Unknown semconv names in `--only` option: '{', '.join(unknown_types)}'"
+        )
         sys.exit(1)
     return types
 
@@ -220,7 +223,6 @@ def setup_parser():
     parser.add_argument(
         "--debug", "-d", help="Enable debug output", action="store_true"
     )
-
     parser.add_argument(
         "--only",
         type=str,

--- a/semantic-conventions/src/opentelemetry/semconv/main.py
+++ b/semantic-conventions/src/opentelemetry/semconv/main.py
@@ -51,12 +51,12 @@ def exclude_file_list(folder: str, pattern: str) -> List[str]:
     return file_names
 
 
-def filter_semconv(semconv, type_filter):
-    if type_filter:
+def filter_semconv(semconv, types_filter):
+    if types_filter:
         semconv.models = {
             id: model
             for id, model in semconv.models.items()
-            if model.GROUP_TYPE_NAME == type_filter
+            if model.GROUP_TYPE_NAME in types_filter
         }
 
 
@@ -65,6 +65,7 @@ def main():
     args = parser.parse_args()
     check_args(args, parser)
     semconv = parse_semconv(args, parser)
+
     filter_semconv(semconv, args.only)
     if len(semconv.models) == 0:
         parser.error("No semantic convention model found!")
@@ -211,7 +212,9 @@ def setup_parser():
     parser.add_argument(
         "--only",
         choices=list(CONVENTION_CLS_BY_GROUP_TYPE.keys()),
-        help="Process only semantic conventions of the specified type.",
+        type=str,
+        nargs="+",
+        help="Process only semantic conventions of the specified types.",
     )
     parser.add_argument(
         "--yaml-root",

--- a/semantic-conventions/src/opentelemetry/semconv/main.py
+++ b/semantic-conventions/src/opentelemetry/semconv/main.py
@@ -65,7 +65,6 @@ def main():
     args = parser.parse_args()
     check_args(args, parser)
     semconv = parse_semconv(args, parser)
-
     filter_semconv(semconv, args.only)
     if len(semconv.models) == 0:
         parser.error("No semantic convention model found!")

--- a/semantic-conventions/src/opentelemetry/semconv/main.py
+++ b/semantic-conventions/src/opentelemetry/semconv/main.py
@@ -213,7 +213,9 @@ def setup_parser():
     parser.add_argument(
         "--only",
         type=str,
-        help="""Generates semantic conventions of the specified types only ({0}).
+        help=f"""Generates semantic conventions of the specified types only
+        ({", ".join(CONVENTION_CLS_BY_GROUP_TYPE.keys())}).
+
         To generate multiple conventions at once, pass comma-separated list of
         convention names, e.g. '--only span,event'.
 
@@ -221,9 +223,7 @@ def setup_parser():
         Resolution of referenced attributes (using `ref`), or semantic conventions
         (using `exclude` or `include`) is done against all semantic convention
         files provided as input using `--yaml-root` or `YAML_FILE` options.
-        """.format(
-            ", ".join(CONVENTION_CLS_BY_GROUP_TYPE.keys())
-        ),
+        """,
     )
     parser.add_argument(
         "--yaml-root",

--- a/semantic-conventions/src/opentelemetry/semconv/main.py
+++ b/semantic-conventions/src/opentelemetry/semconv/main.py
@@ -53,7 +53,7 @@ def exclude_file_list(folder: str, pattern: str) -> List[str]:
 
 def filter_semconv(semconv, types_filter):
     if types_filter:
-        types = types_filter.replace(" ", "").split(',')
+        types = types_filter.replace(" ", "").split(",")
         semconv.models = {
             id: model
             for id, model in semconv.models.items()
@@ -217,11 +217,13 @@ def setup_parser():
         To generate multiple conventions at once, pass comma-separated list of
         convention names, e.g. '--only span,event'.
 
-        The `--only` flag filters the output and does not apply to input. 
+        The `--only` flag filters the output and does not apply to input.
         Resolution of referenced attributes (using `ref`), or semantic conventions
         (using `exclude` or `include`) is done against all semantic convention
         files provided as input using `--yaml-root` or `YAML_FILE` options.
-        """.format(', '.join(CONVENTION_CLS_BY_GROUP_TYPE.keys())),
+        """.format(
+            ", ".join(CONVENTION_CLS_BY_GROUP_TYPE.keys())
+        ),
     )
     parser.add_argument(
         "--yaml-root",

--- a/semantic-conventions/src/opentelemetry/semconv/main.py
+++ b/semantic-conventions/src/opentelemetry/semconv/main.py
@@ -53,10 +53,11 @@ def exclude_file_list(folder: str, pattern: str) -> List[str]:
 
 def filter_semconv(semconv, types_filter):
     if types_filter:
+        types = types_filter.replace(" ", "").split(',')
         semconv.models = {
             id: model
             for id, model in semconv.models.items()
-            if model.GROUP_TYPE_NAME in types_filter
+            if model.GROUP_TYPE_NAME in types
         }
 
 
@@ -208,12 +209,19 @@ def setup_parser():
     parser.add_argument(
         "--debug", "-d", help="Enable debug output", action="store_true"
     )
+
     parser.add_argument(
         "--only",
-        choices=list(CONVENTION_CLS_BY_GROUP_TYPE.keys()),
         type=str,
-        nargs="+",
-        help="Process only semantic conventions of the specified types.",
+        help="""Generates semantic conventions of the specified types only ({0}).
+        To generate multiple conventions at once, pass comma-separated list of
+        convention names, e.g. '--only span,event'.
+
+        The `--only` flag filters the output and does not apply to input. 
+        Resolution of referenced attributes (using `ref`), or semantic conventions
+        (using `exclude` or `include`) is done against all semantic convention
+        files provided as input using `--yaml-root` or `YAML_FILE` options.
+        """.format(', '.join(CONVENTION_CLS_BY_GROUP_TYPE.keys())),
     )
     parser.add_argument(
         "--yaml-root",

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -250,7 +250,7 @@ class MetricGroupSemanticConvention(BaseSemanticConvention):
     GROUP_TYPE_NAME = "metric_group"
 
 
-class MetricSemanticConvention(MetricGroupSemanticConvention):
+class gitMetricSemanticConvention(MetricGroupSemanticConvention):
     GROUP_TYPE_NAME = "metric"
 
     allowed_keys: Tuple[str, ...] = BaseSemanticConvention.allowed_keys + (

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -250,7 +250,7 @@ class MetricGroupSemanticConvention(BaseSemanticConvention):
     GROUP_TYPE_NAME = "metric_group"
 
 
-class gitMetricSemanticConvention(MetricGroupSemanticConvention):
+class MetricSemanticConvention(MetricGroupSemanticConvention):
     GROUP_TYPE_NAME = "metric"
 
     allowed_keys: Tuple[str, ...] = BaseSemanticConvention.allowed_keys + (


### PR DESCRIPTION
Alternative approach to #156

Usage diff: 

Java generates all semconv except resources into one file
```diff
docker run --rm \
  -v ${SCRIPT_DIR}/opentelemetry-specification/semantic_conventions:/source \
  -v ${SCRIPT_DIR}/templates:/templates \
  -v ${ROOT_DIR}/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/:/output \
  otel/semconvgen:$GENERATOR_VERSION \
-  --exclude resource/** \
+  --only span,event,attribute_group,scope \
  -f /source code \
 ...
```

Resources:

```diff
docker run --rm \
- -v ${SCRIPT_DIR}/opentelemetry-specification/semantic_conventions/resource/:/source \
+ -v ${SCRIPT_DIR}/opentelemetry-specification/semantic_conventions:/source \
  -v ${SCRIPT_DIR}/templates:/templates \
  -v ${ROOT_DIR}/semconv/src/main/java/io/opentelemetry/semconv/resource/attributes/:/output \
  semconvgen:$GENERATOR_VERSION \
+ --only resource \
  -f /source code \
....
```