### PR TITLE
Add frozen stability level and change default stability level to experimental

### DIFF
--- a/semantic-conventions/CHANGELOG.md
+++ b/semantic-conventions/CHANGELOG.md
@@ -4,6 +4,9 @@ Please update the changelog as part of any significant pull request.
 
 ## Unreleased
 
+- Support `frozen` stability level and change default stability level from `stable` to `experimental`
+  ([#TODO](https://github.com/open-telemetry/build-tools/pull/TODO))
+
 ## v0.18.0
 
 - Allow multiple semconv in --only flag

--- a/semantic-conventions/CHANGELOG.md
+++ b/semantic-conventions/CHANGELOG.md
@@ -5,7 +5,7 @@ Please update the changelog as part of any significant pull request.
 ## Unreleased
 
 - Support `frozen` stability level and change default stability level from `stable` to `experimental`
-  ([#TODO](https://github.com/open-telemetry/build-tools/pull/TODO))
+  ([#170](https://github.com/open-telemetry/build-tools/pull/170))
 
 ## v0.18.0
 

--- a/semantic-conventions/src/opentelemetry/semconv/main.py
+++ b/semantic-conventions/src/opentelemetry/semconv/main.py
@@ -82,6 +82,7 @@ def process_markdown(semconv, args):
     options = MarkdownOptions(
         check_only=args.md_check,
         enable_stable=args.md_stable,
+        enable_frozen=args.md_frozen,        
         enable_experimental=args.md_experimental,
         enable_deprecated=args.md_enable_deprecated,
         use_badge=args.md_use_badges,
@@ -200,6 +201,12 @@ def add_md_parser(subparsers):
         required=False,
         action="store_true",
     )
+    parser.add_argument(
+        "--md-frozen",
+        help="Add labels to attributes marked as frozen.",
+        required=False,
+        action="store_true",
+    )    
     parser.add_argument(
         "--md-experimental",
         help="Add labels to attributes marked as experimental.",

--- a/semantic-conventions/src/opentelemetry/semconv/main.py
+++ b/semantic-conventions/src/opentelemetry/semconv/main.py
@@ -82,7 +82,7 @@ def process_markdown(semconv, args):
     options = MarkdownOptions(
         check_only=args.md_check,
         enable_stable=args.md_stable,
-        enable_frozen=args.md_frozen,        
+        enable_frozen=args.md_frozen,
         enable_experimental=args.md_experimental,
         enable_deprecated=args.md_enable_deprecated,
         use_badge=args.md_use_badges,
@@ -206,7 +206,7 @@ def add_md_parser(subparsers):
         help="Add labels to attributes marked as frozen.",
         required=False,
         action="store_true",
-    )    
+    )
     parser.add_argument(
         "--md-experimental",
         help="Add labels to attributes marked as experimental.",

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
@@ -39,6 +39,7 @@ class StabilityLevel(Enum):
     STABLE = 1
     EXPERIMENTAL = 2
     DEPRECATED = 3
+    FROZEN = 4
 
 
 def unique_attributes(attributes):
@@ -192,7 +193,7 @@ class SemanticAttribute:
                 )
                 msg = f"Semantic convention stability set to deprecated but attribute '{attr_id}' is {stability}"
                 raise ValidationError.from_yaml_pos(position, msg)
-            stability = stability or semconv_stability or StabilityLevel.STABLE
+            stability = stability or semconv_stability or StabilityLevel.EXPERIMENTAL
             sampling_relevant = (
                 AttributeType.to_bool("sampling_relevant", attribute)
                 if attribute.get("sampling_relevant")
@@ -314,6 +315,7 @@ class SemanticAttribute:
             "deprecated": StabilityLevel.DEPRECATED,
             "experimental": StabilityLevel.EXPERIMENTAL,
             "stable": StabilityLevel.STABLE,
+            "frozen": StabilityLevel.FROZEN,
         }
         val = stability_value_map.get(stability_value)
         if val is not None:

--- a/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
@@ -122,8 +122,7 @@ class MarkdownRenderer:
         ):
             description = f"{self.options.md_snippet_by_stability_level[StabilityLevel.EXPERIMENTAL]}<br>"
         elif (
-            attribute.stability == StabilityLevel.FROZEN
-            and self.options.enable_frozen
+            attribute.stability == StabilityLevel.FROZEN and self.options.enable_frozen
         ):
             description = f"{self.options.md_snippet_by_stability_level[StabilityLevel.FROZEN]}<br>"
 

--- a/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
@@ -121,6 +121,12 @@ class MarkdownRenderer:
             and self.options.enable_experimental
         ):
             description = f"{self.options.md_snippet_by_stability_level[StabilityLevel.EXPERIMENTAL]}<br>"
+        elif (
+            attribute.stability == StabilityLevel.FROZEN
+            and self.options.enable_frozen
+        ):
+            description = f"{self.options.md_snippet_by_stability_level[StabilityLevel.FROZEN]}<br>"
+
         description += attribute.brief
         if attribute.note:
             self.render_ctx.add_note(attribute.note)

--- a/semantic-conventions/src/opentelemetry/semconv/templating/markdown/options.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/markdown/options.py
@@ -25,7 +25,7 @@ class MarkdownOptions:
         StabilityLevel.DEPRECATED: "![Deprecated](https://img.shields.io/badge/-deprecated-red)",
         StabilityLevel.EXPERIMENTAL: "![Experimental](https://img.shields.io/badge/-experimental-blue)",
         StabilityLevel.STABLE: "![Stable](https://img.shields.io/badge/-stable-lightgreen)",
-        StabilityLevel.FROZEN: "![Frozen](https://img.shields.io/badge/-frozen-yellow)"
+        StabilityLevel.FROZEN: "![Frozen](https://img.shields.io/badge/-frozen-yellow)",
     }
 
     _label_map = {
@@ -37,7 +37,7 @@ class MarkdownOptions:
 
     check_only: bool = False
     enable_stable: bool = False
-    enable_frozen: bool = False    
+    enable_frozen: bool = False
     enable_experimental: bool = False
     enable_deprecated: bool = True
     use_badge: bool = False

--- a/semantic-conventions/src/opentelemetry/semconv/templating/markdown/options.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/markdown/options.py
@@ -25,16 +25,19 @@ class MarkdownOptions:
         StabilityLevel.DEPRECATED: "![Deprecated](https://img.shields.io/badge/-deprecated-red)",
         StabilityLevel.EXPERIMENTAL: "![Experimental](https://img.shields.io/badge/-experimental-blue)",
         StabilityLevel.STABLE: "![Stable](https://img.shields.io/badge/-stable-lightgreen)",
+        StabilityLevel.FROZEN: "![Frozen](https://img.shields.io/badge/-frozen-yellow)"
     }
 
     _label_map = {
         StabilityLevel.DEPRECATED: "**Deprecated: {}**",
         StabilityLevel.EXPERIMENTAL: "**Experimental**",
         StabilityLevel.STABLE: "**Stable**",
+        StabilityLevel.FROZEN: "**Frozen**",
     }
 
     check_only: bool = False
     enable_stable: bool = False
+    enable_frozen: bool = False    
     enable_experimental: bool = False
     enable_deprecated: bool = True
     use_badge: bool = False

--- a/semantic-conventions/src/tests/data/markdown/stability/badges_expected.md
+++ b/semantic-conventions/src/tests/data/markdown/stability/badges_expected.md
@@ -6,5 +6,6 @@
 | [`test.exp_attr`](labels_expected.md) | boolean |  |  | Required |
 | [`test.stable_attr`](labels_expected.md) | boolean | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br> |  | Required |
 | [`test.deprecated_attr`](labels_expected.md) | boolean |  |  | Required |
-| [`test.def_stability`](labels_expected.md) | boolean | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br> |  | Required |
+| [`test.def_stability`](labels_expected.md) | boolean |  |  | Required |
+| [`test.frozen_attr`](labels_expected.md) | boolean | ![Frozen](https://img.shields.io/badge/-frozen-yellow)<br> |  | Required |
 <!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/markdown/stability/badges_expected.md
+++ b/semantic-conventions/src/tests/data/markdown/stability/badges_expected.md
@@ -7,5 +7,5 @@
 | [`test.stable_attr`](labels_expected.md) | boolean | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br> |  | Required |
 | [`test.deprecated_attr`](labels_expected.md) | boolean |  |  | Required |
 | [`test.def_stability`](labels_expected.md) | boolean |  |  | Required |
-| [`test.frozen_attr`](labels_expected.md) | boolean | ![Frozen](https://img.shields.io/badge/-frozen-yellow)<br> |  | Required |
+| [`test.frozen_attr`](labels_expected.md) | boolean | ![Frozen](https://img.shields.io/badge/-frozen-yellow)<br>Frozen attribute brief |  | Required |
 <!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/markdown/stability/labels_expected.md
+++ b/semantic-conventions/src/tests/data/markdown/stability/labels_expected.md
@@ -7,5 +7,5 @@
 | [`test.stable_attr`](labels_expected.md) | boolean |  |  | Required |
 | [`test.deprecated_attr`](labels_expected.md) | boolean |  |  | Required |
 | [`test.def_stability`](labels_expected.md) | boolean |  |  | Required |
-| [`test.frozen_attr`](labels_expected.md) | boolean |  |  | Required |
+| [`test.frozen_attr`](labels_expected.md) | boolean | Frozen attribute brief |  | Required |
 <!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/markdown/stability/labels_expected.md
+++ b/semantic-conventions/src/tests/data/markdown/stability/labels_expected.md
@@ -7,4 +7,5 @@
 | [`test.stable_attr`](labels_expected.md) | boolean |  |  | Required |
 | [`test.deprecated_attr`](labels_expected.md) | boolean |  |  | Required |
 | [`test.def_stability`](labels_expected.md) | boolean |  |  | Required |
+| [`test.frozen_attr`](labels_expected.md) | boolean |  |  | Required |
 <!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/markdown/stability/stability.yaml
+++ b/semantic-conventions/src/tests/data/markdown/stability/stability.yaml
@@ -27,4 +27,4 @@ groups:
         type: boolean
         requirement_level: required
         stability: frozen
-        brief: ""
+        brief: Frozen attribute brief

--- a/semantic-conventions/src/tests/data/markdown/stability/stability.yaml
+++ b/semantic-conventions/src/tests/data/markdown/stability/stability.yaml
@@ -23,3 +23,8 @@ groups:
         type: boolean
         requirement_level: required
         brief: ""
+      - id: frozen_attr
+        type: boolean
+        requirement_level: required
+        stability: frozen
+        brief: ""

--- a/semantic-conventions/src/tests/data/yaml/stability.yaml
+++ b/semantic-conventions/src/tests/data/yaml/stability.yaml
@@ -22,12 +22,12 @@ groups:
       - id: def_stability
         type: boolean
         requirement_level: required
-        brief: ""
+        brief:
       - id: frozen_attr
         type: boolean
         requirement_level: required
         stability: frozen
-        brief: ""
+        brief: Frozen attribute brief
 
   - id: parent_default
     type: span

--- a/semantic-conventions/src/tests/data/yaml/stability.yaml
+++ b/semantic-conventions/src/tests/data/yaml/stability.yaml
@@ -23,6 +23,11 @@ groups:
         type: boolean
         requirement_level: required
         brief: ""
+      - id: frozen_attr
+        type: boolean
+        requirement_level: required
+        stability: frozen
+        brief: ""
 
   - id: parent_default
     type: span

--- a/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
+++ b/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
@@ -472,7 +472,7 @@ class TestCorrectParse(unittest.TestCase):
         self.assertEqual(len(semconv.models), 6)
 
         model = list(semconv.models.values())[0]
-        self.assertEqual(len(model.attributes), 4)
+        self.assertEqual(len(model.attributes), 5)
         self.assertEqual(model.stability, None)
 
         attr = model.attributes[0]
@@ -489,7 +489,11 @@ class TestCorrectParse(unittest.TestCase):
 
         attr = model.attributes[3]
         self.assertEqual(attr.attr_id, "def_stability")
-        self.assertEqual(attr.stability, StabilityLevel.STABLE)
+        self.assertEqual(attr.stability, StabilityLevel.EXPERIMENTAL)
+
+        attr = model.attributes[4]
+        self.assertEqual(attr.attr_id, "frozen_attr")
+        self.assertEqual(attr.stability, StabilityLevel.FROZEN)
 
         model = list(semconv.models.values())[1]
         self.assertEqual(len(model.attributes), 2)

--- a/semantic-conventions/src/tests/semconv/templating/test_markdown.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_markdown.py
@@ -37,7 +37,7 @@ class TestCorrectMarkdown(unittest.TestCase):
         self.check("markdown/stability/", expected_name="labels_expected.md")
         self.check(
             "markdown/stability/",
-            MarkdownOptions(enable_stable=True, use_badge=True),
+            MarkdownOptions(enable_stable=True, enable_frozen=True, use_badge=True),
             expected_name="badges_expected.md",
         )
 

--- a/semantic-conventions/syntax.md
+++ b/semantic-conventions/syntax.md
@@ -65,6 +65,7 @@ extends ::= string
 stability ::= "deprecated"
           |   "experimental"
           |   "stable"
+          |   "frozen"
 
 deprecated ::= <description>
 


### PR DESCRIPTION
In preparation for https://github.com/open-telemetry/opentelemetry-specification/issues/3279, it'd be great to have a formal way to declare attributes as frozen. 