### PR TITLE
Render notes on metric semconv tables

### DIFF
--- a/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
@@ -233,7 +233,6 @@ class MarkdownRenderer:
         output.write(
             f"| `{semconv.metric_name}` | {instrument} | `{semconv.unit}` | {description} |\n"
         )
-
         self.to_markdown_notes(output)
 
     def to_markdown_anyof(self, anyof: AnyOf, output: io.StringIO):

--- a/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
@@ -224,9 +224,16 @@ class MarkdownRenderer:
             "| Name     | Instrument Type | Unit (UCUM) | Description    |\n"
             "| -------- | --------------- | ----------- | -------------- |\n"
         )
+
+        description = semconv.brief
+        if semconv.note:
+            self.render_ctx.add_note(semconv.note)
+            description += f" [{len(self.render_ctx.notes)}]"
+
         output.write(
-            f"| `{semconv.metric_name}` | {instrument} | `{semconv.unit}` | {semconv.brief} |\n"
+            f"| `{semconv.metric_name}` | {instrument} | `{semconv.unit}` | {description} |\n"
         )
+
         self.to_markdown_notes(output)
 
     def to_markdown_anyof(self, anyof: AnyOf, output: io.StringIO):

--- a/semantic-conventions/src/tests/data/markdown/metrics_tables/expected.md
+++ b/semantic-conventions/src/tests/data/markdown/metrics_tables/expected.md
@@ -4,7 +4,9 @@
 <!-- semconv metric.foo.size(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `foo.size` | Histogram | `{bars}` | Measures the size of foo. |
+| `foo.size` | Histogram | `{bars}` | Measures the size of foo. [1] |
+
+**[1]:** Some notes on metric.foo.size
 <!-- endsemconv -->
 
 **Attributes for `foo.size`**
@@ -19,13 +21,17 @@
 <!-- semconv metric.foo.active_eggs(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `foo.active_eggs` | UpDownCounter | `{cartons}` | Measures how many eggs are currently active. |
+| `foo.active_eggs` | UpDownCounter | `{cartons}` | Measures how many eggs are currently active. [1] |
+
+**[1]:** Some notes on metric.foo.active_eggs
 <!-- endsemconv -->
 
 **Attributes for `foo.active_eggs`**
 <!-- semconv metric.foo.active_eggs -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `bar.egg.type` | string | Type of egg. | `chicken`; `emu`; `dragon` | Conditionally Required: if available to instrumentation. |
+| `bar.egg.type` | string | Type of egg. [1] | `chicken`; `emu`; `dragon` | Conditionally Required: if available to instrumentation. |
 | `http.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Opt-In |
+
+**[1]:** Some notes on attribute
 <!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/markdown/metrics_tables/expected.md
+++ b/semantic-conventions/src/tests/data/markdown/metrics_tables/expected.md
@@ -21,9 +21,7 @@
 <!-- semconv metric.foo.active_eggs(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `foo.active_eggs` | UpDownCounter | `{cartons}` | Measures how many eggs are currently active. [1] |
-
-**[1]:** Some notes on metric.foo.active_eggs
+| `foo.active_eggs` | UpDownCounter | `{cartons}` | Measures how many eggs are currently active. |
 <!-- endsemconv -->
 
 **Attributes for `foo.active_eggs`**

--- a/semantic-conventions/src/tests/data/yaml/metrics.yaml
+++ b/semantic-conventions/src/tests/data/yaml/metrics.yaml
@@ -10,6 +10,8 @@ groups:
         type: string
         brief: 'Type of egg.'
         examples: ["chicken", "emu", "dragon"]
+        note: >
+          Some notes on attribute
 
   - id: metric.foo.size
     prefix: foo
@@ -18,6 +20,8 @@ groups:
     brief: "Measures the size of foo."
     instrument: histogram
     unit: "{bars}"
+    note: >
+      Some notes on metric.foo.size
     attributes:
       - ref: http.method
         requirement_level: required
@@ -32,6 +36,8 @@ groups:
     brief: "Measures how many eggs are currently active."
     instrument: updowncounter
     unit: "{cartons}"
+    note: >
+      Some notes on metric.foo.active_eggs
     attributes: 
       - ref: http.method
         requirement_level: opt_in

--- a/semantic-conventions/src/tests/data/yaml/metrics.yaml
+++ b/semantic-conventions/src/tests/data/yaml/metrics.yaml
@@ -36,8 +36,6 @@ groups:
     brief: "Measures how many eggs are currently active."
     instrument: updowncounter
     unit: "{cartons}"
-    note: >
-      Some notes on metric.foo.active_eggs
     attributes: 
       - ref: http.method
         requirement_level: opt_in


### PR DESCRIPTION
resolves #167, part of #15.

This only targets metrics, as for that we have a well-defined way to render in markdown (`to_markdown_metric_table`). For other convention types such as `resource` we don't have a well-defined markdown "template" on how we want them to look so I left it for now. 

cc @trask 