### PR TITLE
Add semantic convention approvers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,4 +16,4 @@
 *   @open-telemetry/specs-approvers
 
 # Owners for the semantic conventions generator tool
-/semantic-conventions/      @open-telemetry/specs-approvers @Oberon00
+/semantic-conventions/      @open-telemetry/specs-approvers @open-telemetry/specs-semconv-approvers


### PR DESCRIPTION
Quite often changes to our semantic conventions tooling originate from requests and discussions in https://github.com/open-telemetry/semantic-conventions, so I think it would make sense if @open-telemetry/specs-semconv-approvers would also co-own the tooling here. They usually have most of the context and are the front-line stakeholders in semconv tooling.