### PR TITLE
Enable rendering of "template" attributes in table generation

### DIFF
--- a/semantic-conventions/CHANGELOG.md
+++ b/semantic-conventions/CHANGELOG.md
@@ -4,6 +4,9 @@ Please update the changelog as part of any significant pull request.
 
 ## Unreleased
 
+- Render template-type attributes from yaml files
+  ([#186](https://github.com/open-telemetry/build-tools/pull/186))
+
 ## v0.19.0
 
 - Render notes on metric semconv tables

--- a/semantic-conventions/semconv.schema.json
+++ b/semantic-conventions/semconv.schema.json
@@ -287,7 +287,15 @@
 								"string[]",
 								"int[]",
 								"double[]",
-								"boolean[]"
+								"boolean[]",
+								"template[string]",
+								"template[int]",
+								"template[double]",
+								"template[boolean]",
+								"template[string[]]",
+								"template[int[]]",
+								"template[double[]]",
+								"template[boolean[]]"
 							],
 							"description": "literal denoting the type"
 						},

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
@@ -77,6 +77,14 @@ class SemanticAttribute:
         return replace(self, inherited=True)
 
     @property
+    def core_type(self):
+        return (
+            AttributeType.get_core_template_type(self.attr_type)
+            if AttributeType.is_template_type(self.attr_type)
+            else self.attr_type
+        )
+
+    @property
     def is_local(self):
         return not self.imported and not self.inherited
 

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -590,6 +590,12 @@ class SemanticConventionSet:
             output.extend(semconv.attributes)
         return output
 
+    def attribute_templates(self):
+        output = []
+        for semconv in self.models.values():
+            output.extend(semconv.attribute_templates)
+        return output
+
 
 CONVENTION_CLS_BY_GROUP_TYPE = {
     cls.GROUP_TYPE_NAME: cls

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -23,6 +23,7 @@ from ruamel.yaml import YAML
 from opentelemetry.semconv.model.constraints import AnyOf, Include, parse_constraints
 from opentelemetry.semconv.model.exceptions import ValidationError
 from opentelemetry.semconv.model.semantic_attribute import (
+    AttributeType,
     RequirementLevel,
     SemanticAttribute,
     unique_attributes,
@@ -111,6 +112,30 @@ class BaseSemanticConvention(ValidatableYamlNode):
 
     @property
     def attributes(self):
+        if not hasattr(self, "attrs_by_name"):
+            return []
+
+        return list(
+            filter(
+                lambda attr: not AttributeType.is_template_type(attr.attr_type),
+                list(self.attrs_by_name.values()),
+            )
+        )
+
+    @property
+    def attribute_templates(self):
+        if not hasattr(self, "attrs_by_name"):
+            return []
+
+        return list(
+            filter(
+                lambda attr: AttributeType.is_template_type(attr.attr_type),
+                list(self.attrs_by_name.values()),
+            )
+        )
+
+    @property
+    def attributes_and_templates(self):
         if not hasattr(self, "attrs_by_name"):
             return []
 

--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -16,7 +16,7 @@ import sys
 import typing
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 from ruamel.yaml import YAML
 
@@ -112,34 +112,26 @@ class BaseSemanticConvention(ValidatableYamlNode):
 
     @property
     def attributes(self):
-        if not hasattr(self, "attrs_by_name"):
-            return []
-
-        return list(
-            filter(
-                lambda attr: not AttributeType.is_template_type(attr.attr_type),
-                list(self.attrs_by_name.values()),
-            )
-        )
+        return self._get_attributes(False)
 
     @property
     def attribute_templates(self):
-        if not hasattr(self, "attrs_by_name"):
-            return []
-
-        return list(
-            filter(
-                lambda attr: AttributeType.is_template_type(attr.attr_type),
-                list(self.attrs_by_name.values()),
-            )
-        )
+        return self._get_attributes(True)
 
     @property
     def attributes_and_templates(self):
+        return self._get_attributes(None)
+
+    def _get_attributes(self, templates: Optional[bool]):
         if not hasattr(self, "attrs_by_name"):
             return []
 
-        return list(self.attrs_by_name.values())
+        return [
+            attr
+            for attr in self.attrs_by_name.values()
+            if templates is None
+            or templates == AttributeType.is_template_type(attr.attr_type)
+        ]
 
     def __init__(self, group):
         super().__init__(group)

--- a/semantic-conventions/src/opentelemetry/semconv/templating/code.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/code.py
@@ -188,6 +188,7 @@ class CodeRenderer:
             "template": template_path,
             "semconvs": semconvset.models,
             "attributes": semconvset.attributes(),
+            "attribute_templates": semconvset.attribute_templates(),
         }
         data.update(self.parameters)
         return data

--- a/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/markdown/__init__.py
@@ -22,6 +22,7 @@ from pathlib import PurePath
 
 from opentelemetry.semconv.model.constraints import AnyOf, Include
 from opentelemetry.semconv.model.semantic_attribute import (
+    AttributeType,
     EnumAttributeType,
     EnumMember,
     RequirementLevel,
@@ -97,12 +98,14 @@ class MarkdownRenderer:
         """
         This method renders attributes as markdown table entry
         """
-        name = self.render_attribute_id(attribute.fqn)
+        name = self.render_fqn_for_attribute(attribute)
         attr_type = (
             "enum"
             if isinstance(attribute.attr_type, EnumAttributeType)
             else attribute.attr_type
         )
+        if AttributeType.is_template_type(attr_type):
+            attr_type = AttributeType.get_core_template_type(attr_type)
         description = ""
         if attribute.deprecated and self.options.enable_deprecated:
             if "deprecated" in attribute.deprecated.lower():
@@ -184,7 +187,8 @@ class MarkdownRenderer:
     ):
         attr_to_print = []
         for attr in sorted(
-            semconv.attributes, key=lambda a: "" if a.ref is None else a.ref
+            semconv.attributes_and_templates,
+            key=lambda a: "" if a.ref is None else a.ref,
         ):
             if self.render_ctx.group_key is not None:
                 if attr.tag == self.render_ctx.group_key:
@@ -192,6 +196,7 @@ class MarkdownRenderer:
                 continue
             if self.render_ctx.is_full or attr.is_local:
                 attr_to_print.append(attr)
+
         if self.render_ctx.group_key is not None and not attr_to_print:
             raise ValueError(
                 f"No attributes retained for '{semconv.semconv_id}' filtering by '{self.render_ctx.group_key}'"
@@ -275,7 +280,7 @@ class MarkdownRenderer:
             )
 
             for attr in sampling_relevant_attrs:
-                output.write("* " + self.render_attribute_id(attr.fqn) + "\n")
+                output.write("* " + self.render_fqn_for_attribute(attr) + "\n")
 
     @staticmethod
     def to_markdown_unit_table(members, output: io.StringIO):
@@ -325,19 +330,35 @@ class MarkdownRenderer:
             if notes:
                 output.write("\n")
 
+    def render_fqn_for_attribute(self, attribute):
+        diff = self.get_attr_reference_diff(attribute.fqn)
+        name = attribute.fqn
+        if AttributeType.is_template_type(attribute.attr_type):
+            name = f"{attribute.fqn}.<key>"
+
+        if diff is not None:
+            return f"[`{name}`]({diff})"
+        return f"`{name}`"
+
     def render_attribute_id(self, attribute_id):
         """
         Method to render in markdown an attribute id. If the id points to an attribute in another rendered table, a
         markdown link is introduced.
         """
+        diff = self.get_attr_reference_diff(attribute_id)
+        if diff is not None:
+            return f"[`{attribute_id}`]({diff})"
+        return f"`{attribute_id}`"
+
+    def get_attr_reference_diff(self, attribute_id):
         md_file = self.filename_for_attr_fqn.get(attribute_id)
         if md_file:
             path = PurePath(self.render_ctx.current_md)
             if path.as_posix() != PurePath(md_file).as_posix():
                 diff = PurePath(os.path.relpath(md_file, start=path.parent)).as_posix()
                 if diff != ".":
-                    return f"[`{attribute_id}`]({diff})"
-        return f"`{attribute_id}`"
+                    return diff
+        return None
 
     def to_markdown_constraint(
         self,
@@ -390,7 +411,9 @@ class MarkdownRenderer:
                         )
                     a: SemanticAttribute
                     valid_attr = (
-                        a for a in semconv.attributes if a.is_local and not a.ref
+                        a
+                        for a in semconv.attributes_and_templates
+                        if a.is_local and not a.ref
                     )
                     for attr in valid_attr:
                         m[attr.fqn] = md

--- a/semantic-conventions/src/tests/data/jinja/attribute_templates/expected.java
+++ b/semantic-conventions/src/tests/data/jinja/attribute_templates/expected.java
@@ -12,4 +12,9 @@ class AttributesTemplate {
   * this is the description of the second attribute template. It's a number.
   */
   public static final AttributeKey<Long> ATTRIBUTE_TEMPLATE_TWO = longKey("attribute_template_two");
+
+  /**
+  * this is the description of the third attribute template. It's a boolean.
+  */
+  public static final AttributeKey<Boolean> ATTRIBUTE_THREE = booleanKey("attribute_three");
 }

--- a/semantic-conventions/src/tests/data/jinja/attribute_templates/expected.java
+++ b/semantic-conventions/src/tests/data/jinja/attribute_templates/expected.java
@@ -1,0 +1,15 @@
+
+package io.opentelemetry.instrumentation.api.attributetemplates;
+
+class AttributesTemplate {
+
+  /**
+  * this is the description of the first attribute template
+  */
+  public static final AttributeKey<String> ATTRIBUTE_TEMPLATE_ONE = stringKey("attribute_template_one");
+
+  /**
+  * this is the description of the second attribute template. It's a number.
+  */
+  public static final AttributeKey<Long> ATTRIBUTE_TEMPLATE_TWO = longKey("attribute_template_two");
+}

--- a/semantic-conventions/src/tests/data/jinja/attribute_templates/template
+++ b/semantic-conventions/src/tests/data/jinja/attribute_templates/template
@@ -1,0 +1,62 @@
+{%- macro to_java_return_type(type) -%}
+  {%- if type == "string" -%}
+    String
+  {%- elif type == "string[]" -%}
+    List<String>
+  {%- elif type == "boolean" -%}
+    boolean
+  {%- elif type == "int" -%}
+    long
+  {%- elif type == "double" -%}
+    double
+  {%- else -%}
+    {{type}}
+  {%- endif -%}
+{%- endmacro %}
+{%- macro to_java_key_type(type) -%}
+  {%- if type == "string" -%}
+    stringKey
+  {%- elif type == "string[]" -%}
+    stringArrayKey
+  {%- elif type == "boolean" -%}
+    booleanKey
+  {%- elif type == "int" -%}
+    longKey
+  {%- elif type == "double" -%}
+    doubleKey
+  {%- else -%}
+    {{lowerFirst(type)}}Key
+  {%- endif -%}
+{%- endmacro %}
+{%- macro print_value(type, value) -%}
+  {{ "\"" if type == "String"}}{{value}}{{ "\"" if type == "String"}}
+{%- endmacro %}
+{%- macro upFirst(text) -%}
+  {{ text[0]|upper}}{{text[1:] }}
+{%- endmacro %}
+{%- macro lowerFirst(text) -%}
+  {{ text[0]|lower}}{{text[1:] }}
+{%- endmacro %}
+package io.opentelemetry.instrumentation.api.attributetemplates;
+
+class AttributesTemplate {
+{%- for attribute_template in attribute_templates if attribute_template.is_local and not attribute_template.ref %}
+
+  /**
+  * {{attribute_template.brief | render_markdown(code="{{@code {0}}}", paragraph="{0}")}}
+    {%- if attribute_template.note %}
+  *
+  * <p>Notes:
+    <ul> {{attribute_template.note | render_markdown(code="{{@code {0}}}", paragraph="<li>{0}</li>", list="{0}")}} </ul>
+    {%- endif %}
+    {%- if (attribute_template.stability | string())  == "StabilityLevel.DEPRECATED" %}
+  *
+  * @deprecated {{attribute_template.brief | to_doc_brief}}.
+    {%- endif %}
+  */
+    {%- if (attribute_template.stability | string()) == "StabilityLevel.DEPRECATED"  %}
+  @Deprecated
+    {%- endif %}
+  public static final AttributeKey<{{upFirst(to_java_return_type(attribute_template.core_type | string))}}> {{attribute_template.fqn | to_const_name}} = {{to_java_key_type(attribute_template.core_type | string)}}("{{attribute_template.fqn}}");
+  {%- endfor %}
+}

--- a/semantic-conventions/src/tests/data/jinja/attribute_templates/template
+++ b/semantic-conventions/src/tests/data/jinja/attribute_templates/template
@@ -57,6 +57,25 @@ class AttributesTemplate {
     {%- if (attribute_template.stability | string()) == "StabilityLevel.DEPRECATED"  %}
   @Deprecated
     {%- endif %}
-  public static final AttributeKey<{{upFirst(to_java_return_type(attribute_template.core_type | string))}}> {{attribute_template.fqn | to_const_name}} = {{to_java_key_type(attribute_template.core_type | string)}}("{{attribute_template.fqn}}");
-  {%- endfor %}
+  public static final AttributeKey<{{upFirst(to_java_return_type(attribute_template.instantiated_type | string))}}> {{attribute_template.fqn | to_const_name}} = {{to_java_key_type(attribute_template.instantiated_type | string)}}("{{attribute_template.fqn}}");
+{%- endfor %}
+{%- for attribute in attributes if attribute.is_local and not attribute.ref %}
+
+  /**
+  * {{attribute.brief | render_markdown(code="{{@code {0}}}", paragraph="{0}")}}
+    {%- if attribute.note %}
+  *
+  * <p>Notes:
+    <ul> {{attribute.note | render_markdown(code="{{@code {0}}}", paragraph="<li>{0}</li>", list="{0}")}} </ul>
+    {%- endif %}
+    {%- if (attribute.stability | string())  == "StabilityLevel.DEPRECATED" %}
+  *
+  * @deprecated {{attribute.brief | to_doc_brief}}.
+    {%- endif %}
+  */
+    {%- if (attribute.stability | string()) == "StabilityLevel.DEPRECATED"  %}
+  @Deprecated
+    {%- endif %}
+  public static final AttributeKey<{{upFirst(to_java_return_type(attribute.instantiated_type | string))}}> {{attribute.fqn | to_const_name}} = {{to_java_key_type(attribute.instantiated_type | string)}}("{{attribute.fqn}}");
+{%- endfor %}
 }

--- a/semantic-conventions/src/tests/data/markdown/attribute_templates/attribute_templates.yaml
+++ b/semantic-conventions/src/tests/data/markdown/attribute_templates/attribute_templates.yaml
@@ -1,0 +1,21 @@
+groups:
+  - id: custom_http
+    type: span
+    prefix: custom_http
+    brief: 'This document defines semantic conventions for HTTP client and server Spans.'
+    note: >
+        These conventions can be used for http and https schemes
+        and various HTTP versions like 1.1, 2 and SPDY.
+    attributes:
+      - id: request.header
+        type: template[string[]]
+        brief: >
+          HTTP request headers, `<key>` being the normalized HTTP Header name
+          (lowercase, with - characters replaced by _), the value being the header values.
+        examples: '`http.request.header.content_type=["application/json"]`'
+      - id: request.method
+        type: string
+        requirement_level: required
+        sampling_relevant: false
+        brief: 'HTTP request method.'
+        examples: ["GET", "POST", "HEAD"]

--- a/semantic-conventions/src/tests/data/markdown/attribute_templates/expected.md
+++ b/semantic-conventions/src/tests/data/markdown/attribute_templates/expected.md
@@ -1,0 +1,8 @@
+# Custom HTTP Semantic Conventions
+
+<!-- semconv custom_http -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| `custom_http.request.header.<key>` | string[] | HTTP request headers, `<key>` being the normalized HTTP Header name (lowercase, with - characters replaced by _), the value being the header values. | ``http.request.header.content_type=["application/json"]`` | Recommended |
+| `custom_http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
+<!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/markdown/attribute_templates/input.md
+++ b/semantic-conventions/src/tests/data/markdown/attribute_templates/input.md
@@ -1,0 +1,4 @@
+# Custom HTTP Semantic Conventions
+
+<!-- semconv custom_http -->
+<!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/yaml/attr_templates_code/attribute_templates.yml
+++ b/semantic-conventions/src/tests/data/yaml/attr_templates_code/attribute_templates.yml
@@ -1,0 +1,25 @@
+groups:  
+  - id: test
+    type: attribute_group
+    brief: 'brief'
+    attributes:
+      - id: attribute_template_one
+        tag: tag-one
+        type: template[string]
+        brief: >
+          this is the description of
+          the first attribute template
+        examples: 'This is a good example of the first attribute template'
+      - id: attribute_template_two
+        tag: tag-two
+        type: template[int]
+        brief: >
+          this is the description of
+          the second attribute template. It's a number.
+        examples: [1000, 10, 1]
+      - id: attribute_three
+        tag: tag-three
+        type: boolean
+        brief: >
+          this is the description of
+          the second attribute template. It's a boolean.

--- a/semantic-conventions/src/tests/data/yaml/attr_templates_code/attribute_templates.yml
+++ b/semantic-conventions/src/tests/data/yaml/attr_templates_code/attribute_templates.yml
@@ -22,4 +22,4 @@ groups:
         type: boolean
         brief: >
           this is the description of
-          the second attribute template. It's a boolean.
+          the third attribute template. It's a boolean.

--- a/semantic-conventions/src/tests/data/yaml/attribute_templates.yml
+++ b/semantic-conventions/src/tests/data/yaml/attribute_templates.yml
@@ -1,0 +1,21 @@
+attributes:
+  - id: attribute_template_one
+    tag: tag-one
+    type: template[string]
+    brief: >
+      this is the description of
+      the first attribute template
+    examples: 'This is a good example of the first attribute template'
+  - id: attribute_template_two
+    tag: tag-two
+    type: template[int]
+    brief: >
+      this is the description of
+      the second attribute template. It's a number.
+    examples: [1000, 10, 1]
+  - id: attribute_three
+    tag: tag-three
+    type: boolean
+    brief: >
+      this is the description of
+      the second attribute template. It's a boolean.

--- a/semantic-conventions/src/tests/semconv/templating/test_code.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_code.py
@@ -41,3 +41,22 @@ def test_strip_blocks_enabled(test_file_path, read_test_file):
     )
 
     assert result == expected
+
+
+def test_codegen_attribute_templates(test_file_path, read_test_file):
+    semconv = SemanticConventionSet(debug=False)
+    semconv.parse(
+        test_file_path("yaml", "attr_templates_code", "attribute_templates.yml")
+    )
+    semconv.finish()
+
+    template_path = test_file_path("jinja", "attribute_templates", "template")
+    renderer = CodeRenderer({}, trim_whitespace=False)
+
+    output = io.StringIO()
+    renderer.render(semconv, template_path, output, None)
+    result = output.getvalue()
+
+    expected = read_test_file("jinja", "attribute_templates", "expected.java")
+
+    assert result == expected

--- a/semantic-conventions/src/tests/semconv/templating/test_markdown.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_markdown.py
@@ -142,6 +142,9 @@ class TestCorrectMarkdown(unittest.TestCase):
     def test_attribute_group(self):
         self.check("markdown/attribute_group/")
 
+    def test_attribute_templates(self):
+        self.check("markdown/attribute_templates/")
+
     def check(
         self,
         input_dir: str,

--- a/semantic-conventions/syntax.md
+++ b/semantic-conventions/syntax.md
@@ -86,7 +86,7 @@ simple_type ::= "string"
      |   "double[]"
      |   "boolean[]"
 
-template_type ::= "template[" simple_type "]"
+template_type ::= "template[" simple_type "]" # As a single string
 
 enum ::= [allow_custom_values] members
 
@@ -229,7 +229,7 @@ An attribute is defined by:
     * `"int[]"`: Array of integer attributes.
     * `"double[]"`: Array of double attributes.
     * `"boolean[]"`: Array of booleans attributes.
-  * _template type as string literal:_ `"template[<PRIMITIVE_OR_ARRAY_TYPE>]"` (See later)
+  * _template type as string literal:_ `"template[<PRIMITIVE_OR_ARRAY_TYPE>]"` (See [below](#template-type))
 
   See the [specification of Attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/README.md#attribute) for the definition of the value types.
 - `ref`, optional string, reference an existing attribute, see [below](#ref).
@@ -343,11 +343,11 @@ array of booleans, a template type or an enumeration.
 
 ##### Template type
 
-A template type attribute represents a _key-value set_ of attributes with a common attribute name prefix. The syntax for defining template type attributes is the following:
+A template type attribute represents a _dictionary_ of attributes with a common attribute name prefix. The syntax for defining template type attributes is the following:
 
 `type: template[<PRIMITIVE_OR_ARRAY_TYPE>]`
 
-The `<PRIMITIVE_OR_ARRAY_TYPE>` is one of the above-mentioned primitive or array types (_not_ an enumeration) and specifies the type of the `value` in the key-value pairs. 
+The `<PRIMITIVE_OR_ARRAY_TYPE>` is one of the above-mentioned primitive or array types (_not_ an enum) and specifies the type of the `value` in the dictionary. 
 
 The following is an example for defining a template type attribute and it's resolution:
 
@@ -360,13 +360,13 @@ groups:
       - id: http.request.header
         type: template[string[]]
         brief: >
-          HTTP request headers, `<key>` being the normalized HTTP Header name (lowercase, with `-` characters replaced by `_`), the value being the header values.
+          HTTP request headers, the key being the normalized HTTP header name (lowercase, with `-` characters replaced by `_`), the value being the header values.
         examples: ['http.request.header.content_type=["application/json"]', 'http.request.header.x_forwarded_for=["1.2.3.4", "1.2.3.5"]']
         note: |
           ...
 ```
 
-In this example the definition will be resolved into a key-value set of attributes `http.request.header.<key>` where `<key>` will be replaced by the actual HTTP header name, and the value of the attributes is of type `string[]` that carries the HTTP header value. 
+In this example the definition will be resolved into a dictionary of attributes `http.request.header.<key>` where `<key>` will be replaced by the actual HTTP header name, and the value of the attributes is of type `string[]` that carries the HTTP header value. 
 
 ##### Enumeration
 

--- a/semantic-conventions/syntax.md
+++ b/semantic-conventions/syntax.md
@@ -73,7 +73,11 @@ attributes ::= (id type brief examples | ref [brief] [examples]) [tag] [stabilit
 # ref MUST point to an existing attribute id
 ref ::= id
 
-type ::= "string"
+type ::= simple_type
+     |   template_type
+     |   enum
+
+simple_type ::= "string"
      |   "int"
      |   "double"
      |   "boolean"
@@ -81,7 +85,8 @@ type ::= "string"
      |   "int[]"
      |   "double[]"
      |   "boolean[]"
-     |   enum
+
+template_type ::= "template[" simple_type "]"
 
 enum ::= [allow_custom_values] members
 
@@ -213,17 +218,18 @@ Attribute groups don't have any specific fields and follow the general `semconv`
 An attribute is defined by:
 
 - `id`, string that uniquely identifies the attribute.
-- `type`, either a string literal denoting the type or an enum definition (See later).
+- `type`, either a string literal denoting the type as a primitive or an array type, a template type or an enum definition (See later).
    The accepted string literals are:
-
-  * `"string"`: String attributes.
-  * `"int"`: Integer attributes.
-  * `"double"`: Double attributes.
-  * `"boolean"`: Boolean attributes.
-  * `"string[]"`: Array of strings attributes.
-  * `"int[]"`: Array of integer attributes.
-  * `"double[]"`: Array of double attributes.
-  * `"boolean[]"`: Array of booleans attributes.
+  * _primitive and array types as string literals:_
+    * `"string"`: String attributes.
+    * `"int"`: Integer attributes.
+    * `"double"`: Double attributes.
+    * `"boolean"`: Boolean attributes.
+    * `"string[]"`: Array of strings attributes.
+    * `"int[]"`: Array of integer attributes.
+    * `"double[]"`: Array of double attributes.
+    * `"boolean[]"`: Array of booleans attributes.
+  * _template type as string literal:_ `"template[<PRIMITIVE_OR_ARRAY_TYPE>]"` (See later)
 
   See the [specification of Attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/README.md#attribute) for the definition of the value types.
 - `ref`, optional string, reference an existing attribute, see [below](#ref).
@@ -333,7 +339,38 @@ fields are present in the current attribute definition, they override the inheri
 #### Type
 
 An attribute type can either be a string, int, double, boolean, array of strings, array of int, array of double,
-array of booleans, or an enumeration. If it is an enumeration, additional fields are required:
+array of booleans, a template type or an enumeration. 
+
+##### Template type
+
+A template type attribute represents a _key-value set_ of attributes with a common attribute name prefix. The syntax for defining template type attributes is the following:
+
+`type: template[<PRIMITIVE_OR_ARRAY_TYPE>]`
+
+The `<PRIMITIVE_OR_ARRAY_TYPE>` is one of the above-mentioned primitive or array types (_not_ an enumeration) and specifies the type of the `value` in the key-value pairs. 
+
+The following is an example for defining a template type attribute and it's resolution:
+
+```yaml
+groups:
+  - id: trace.http.common
+    type: attribute_group
+    brief: "..."
+    attributes:
+      - id: http.request.header
+        type: template[string[]]
+        brief: >
+          HTTP request headers, `<key>` being the normalized HTTP Header name (lowercase, with `-` characters replaced by `_`), the value being the header values.
+        examples: ['http.request.header.content_type=["application/json"]', 'http.request.header.x_forwarded_for=["1.2.3.4", "1.2.3.5"]']
+        note: |
+          ...
+```
+
+In this example the definition will be resolved into a key-value set of attributes `http.request.header.<key>` where `<key>` will be replaced by the actual HTTP header name, and the value of the attributes is of type `string[]` that carries the HTTP header value. 
+
+##### Enumeration
+
+If the type is an enumeration, additional fields are required:
 
 - `allow_custom_values`, optional boolean, set to false to not accept values
      other than the specified members. It defaults to `true`.


### PR DESCRIPTION
## Problem
In the semantic conventions we have `template`-style attributes in some places.

Examples are:
- [HTTP request and response headers](https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/http/#http-request-and-response-headers): `http.request.header.<key>`, `http.response.header.<key>`
- [Elasticsearch path parts](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/elasticsearch.md#url-path-parts): `db.elasticsearch.path_parts.<key>` 

This kind of attributes could not be included in the model `.yml` files yet, and thus could not be included in table generation.

## Solution
This PR proposes a fix that enables definition of `template`-style attributes in the YAML files and corresponding table generation.

### How it works
Template-style attributes (i.e. that do not result in a single attribute, but a group of attributes, for example `http.request.header.<key>`) can be defined in a separate `attribute-templates` sub-path in an attribute group.
Attribute templates extend the normal attributes by adding an additional property `parameter_name` that is the name of the parameter in the angle brackets (e.g. `key` in the example above). 

Here is an example YAML file snippet:

```

groups:
  - id: http
    type: span
    prefix: http
    brief: 'This document defines semantic conventions for HTTP client and server Spans.'
    note: >
        These conventions can be used for http and https schemes
        and various HTTP versions like 1.1, 2 and SPDY.
    attribute_templates:                                                 <<---- THIS IS NEW
      - id: request.header
        type: string
        brief: >
          HTTP request headers, `<key>` being the normalized HTTP Header name
          (lowercase, with - characters replaced by _), the value being the header values.
        examples: '`http.request.header.content_type=["application/json"]`'
        parameter_name: key                                             <<---- THIS IS THE NEW PROPERTY
    attributes:
      - id: request.method
        type: string
        requirement_level: required
        sampling_relevant: false
        brief: 'HTTP request method.'
        examples: ["GET", "POST", "HEAD"]
```

This will result in the following markdown result through table generation:

```
<!-- semconv http -->
| Attribute  | Type | Description  | Examples  | Requirement Level |
|---|---|---|---|---|
| `http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
| `http.request.header.<key>` | string | HTTP request headers, `<key>` being the normalized HTTP Header name (lowercase, with - characters replaced by _), the value being the header values. | ``http.request.header.content_type=["application/json"]`` | Recommended |
<!-- endsemconv -->
```

Defining such attributes templates in a separate path in the yaml (instead of listing them under the normal attributes) has the following advantages:

1. These attribute templates have slightly different semantic (compared to normal attributes) as they represent a group of attributes (for which the actual name is runtime dynamic / unknown at specification time). 

1. It does not break code generation for attributes, because it's a separate path that is currently just not considered for code generation. Later, we could even build dedicated code generators for template-style attributes for the different languages. That's something that is currently defined 'manually' in all the SDKs.
1. For markdown table generation, this PR already includes template-style attributes as an additional set of attributes. Hence, template-style attributes can be defined in YAML files and are included in table generation. 
 