### PR TITLE
Added `omit_requirement_level` option for markdown table rendering

### DIFF
--- a/semantic-conventions/src/tests/data/markdown/omit_requirement_level/expected.md
+++ b/semantic-conventions/src/tests/data/markdown/omit_requirement_level/expected.md
@@ -1,0 +1,9 @@
+# Common Attributes
+
+<!-- semconv http(omit_requirement_level) -->
+| Attribute  | Type | Description  | Examples  |
+|---|---|---|---|
+| `http.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` |
+| `http.url` | string | Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]`. Usually the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless. | `https://www.foo.bar/search?q=OpenTelemetry#SemConv` |
+| `http.target` | string | The full request target as passed in a HTTP request line or equivalent. | `/path/12314/?q=ddds#123` |
+<!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/markdown/omit_requirement_level/http.yaml
+++ b/semantic-conventions/src/tests/data/markdown/omit_requirement_level/http.yaml
@@ -1,0 +1,25 @@
+groups:
+  - id: http
+    type: span
+    prefix: http
+    brief: 'This document defines semantic conventions for HTTP client and server Spans.'
+    note: >
+        These conventions can be used for http and https schemes
+        and various HTTP versions like 1.1, 2 and SPDY.
+    attributes:
+      - id: method
+        type: string
+        requirement_level: required
+        sampling_relevant: false
+        brief: 'HTTP request method.'
+        examples: ["GET", "POST", "HEAD"]
+      - id: url
+        type: string
+        brief: >
+            Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]`.
+            Usually the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
+        examples: ['https://www.foo.bar/search?q=OpenTelemetry#SemConv']
+      - id: target
+        type: string
+        brief: 'The full request target as passed in a HTTP request line or equivalent.'
+        examples: ['/path/12314/?q=ddds#123']

--- a/semantic-conventions/src/tests/data/markdown/omit_requirement_level/input.md
+++ b/semantic-conventions/src/tests/data/markdown/omit_requirement_level/input.md
@@ -1,0 +1,4 @@
+# Common Attributes
+
+<!-- semconv http(omit_requirement_level) -->
+<!-- endsemconv -->

--- a/semantic-conventions/src/tests/semconv/templating/test_markdown.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_markdown.py
@@ -133,6 +133,9 @@ class TestCorrectMarkdown(unittest.TestCase):
             ],
         )
 
+    def test_omit_requirement_level(self):
+        self.check("markdown/omit_requirement_level/")
+
     def testSamplingRelevant(self):
         self.check("markdown/sampling_relevant/")
 


### PR DESCRIPTION
When rendering attributes tables outside specific semantic conventions (e.g. in an attributes dictionary), we need a way to omit rendering the `requirement_level` column in the table.

See this proposal:
- https://github.com/open-telemetry/semantic-conventions/issues/197

This PR introduces an optional `omit_requirement_level` parameter in the markdown `semconv_selector` syntax that indicates the table rendering logic to omit rendering the `requirement_level` column in the corresponding attributes table.