### PR TITLE
Proposal: adapting yaml syntax for splitting attribute definition from usage

### DIFF
--- a/semantic-conventions/syntax.md
+++ b/semantic-conventions/syntax.md
@@ -40,8 +40,8 @@ here in `syntax.md` should be considered more authoritative though. Please keep
 All attributes are lower case.
 
 ```ebnf
-groups ::= group {group}
-       | group {group} groups
+groups ::= group
+       | group groups
 
 group ::= semconv
       | namespace

--- a/semantic-conventions/syntax.md
+++ b/semantic-conventions/syntax.md
@@ -40,10 +40,15 @@ here in `syntax.md` should be considered more authoritative though. Please keep
 All attributes are lower case.
 
 ```ebnf
-groups ::= semconv
-       | semconv groups
+groups ::= group {group}
+       | group {group} groups
 
-semconv ::= id [convtype] brief [note] [prefix] [extends] [stability] [deprecated] attributes [constraints] [specificfields]
+group ::= semconv
+      | namespace
+
+namespace ::= id brief [note] prefix [stability] [deprecated] attribute_definitions
+
+semconv ::= id [convtype] brief [note] [extends] [stability] [deprecated] attributes [constraints] [specificfields]
 
 id    ::= string
 
@@ -68,7 +73,13 @@ stability ::= "deprecated"
 
 deprecated ::= <description>
 
-attributes ::= (id type brief examples | ref [brief] [examples]) [tag] [stability] [deprecated] [required] [sampling_relevant] [note]
+attribute_definitions ::= attribute_definition {attribute_definition}
+
+attribute_definition ::= id type brief examples [tag] [stability] [deprecated] [sampling_relevant] [note]
+
+attributes ::= attribute {attribute}
+
+attribute ::= ref [brief] [examples] [tag] [stability] [deprecated] [requirement_level] [sampling_relevant] [note]
 
 # ref MUST point to an existing attribute id
 ref ::= id


### PR DESCRIPTION
This is a proposal to get discussions started around step 2 from https://github.com/open-telemetry/semantic-conventions/issues/197#issuecomment-1649800369. 

proposed model syntax changes summarized:

- new entity `namespace` that is similar to existing `semconv` but:
   - omitting `convtype`, `extends` and `constraints`
   - requiring a `prefix`
   - `attribute_definitions` instead of `attributes`
- new entity `attribute_definitions` that is similar to existing `attributes` but:
   - requiring `id`, `type`, `brief` and `examples`
   - omitting `ref`, `requirement_level`
- changes on `semconv`:
   - omitting to specify a `prefix` (this will be covered in the `namespace` when defining the attributes)
- changes on `attributes`:
   - forbid _defining_ attributes, only `ref` to an `attribute_definition` is allowed
   
   
 That's how it would look like in YAML files:
 
The attribute definition:
```yaml
groups:
  - id: registry.http   <<- THIS is a namespace, because prefix is not allowed for a semconv anymore
    prefix: http            
    brief: 'This document defines semantic convention attributes in the HTTP namespace.'
    attribute_definitions:        <<- NEW: contains only definitions of attributes (without requirement_level, etc.)
      - id: request.body.size
        type: int
        brief: >
          The size of the request payload body in bytes. ...
        examples: 3495
```

The attribute usage in semantic conventions:
```yaml
groups:
  - id: trace.http.common   <<- THIS is a semconv (because prefix is not defined)
    extends: attributes.http.common
    type: attribute_group
    brief: 'This document defines semantic conventions for HTTP client and server Spans.'
    note: >
        These conventions can be used for http and https schemes
        and various HTTP versions like 1.1, 2 and SPDY.
    attributes:         <<- ATTRIBUTES here can only reference attribute definitions, they cannot be defined here anymore
      - ref: http.request.body.size
        requirement_level: required
```

