### PR TITLE
Fixed conditionally_required requirement_level.

### DIFF
--- a/semantic-conventions/CHANGELOG.md
+++ b/semantic-conventions/CHANGELOG.md
@@ -6,6 +6,8 @@ Please update the changelog as part of any significant pull request.
 
 - Render template-type attributes from yaml files
   ([#186](https://github.com/open-telemetry/build-tools/pull/186))
+- Fix conditionally_required definition in semconv.schema.json
+  ([#201](https://github.com/open-telemetry/build-tools/pull/201))
 
 ## v0.20.0
 

--- a/semantic-conventions/semconv.schema.json
+++ b/semantic-conventions/semconv.schema.json
@@ -9,32 +9,16 @@
 			"items": {
 				"anyOf": [
 					{
-						"allOf": [
-							{
-								"$ref": "#/definitions/SemanticConvention"
-							}
-						]
+						"allOf": [{"$ref": "#/definitions/SemanticConvention"}]
 					},
 					{
-						"allOf": [
-							{
-								"$ref": "#/definitions/SpanSemanticConvention"
-							}
-						]
+						"allOf": [{"$ref": "#/definitions/SpanSemanticConvention"}]
 					},
 					{
-						"allOf": [
-							{
-								"$ref": "#/definitions/EventSemanticConvention"
-							}
-						]
+						"allOf": [{"$ref": "#/definitions/EventSemanticConvention"}]
 					},
 					{
-						"allOf": [
-							{
-								"$ref": "#/definitions/MetricSemanticConvention"
-							}
-						]
+						"allOf": [{"$ref": "#/definitions/MetricSemanticConvention"}]
 					}
 				]
 			}
@@ -149,11 +133,7 @@
 			}
 		},
 		"SpanSemanticConvention": {
-			"allOf": [
-				{
-					"$ref": "#/definitions/SemanticConventionBase"
-				}
-			],
+			"allOf": [{ "$ref": "#/definitions/SemanticConventionBase" }],
 			"properties": {
 				"type": {
 					"type": "string",
@@ -173,11 +153,7 @@
 			}
 		},
 		"EventSemanticConvention": {
-			"allOf": [
-				{
-					"$ref": "#/definitions/SemanticConventionBase"
-				}
-			],
+			"allOf": [{ "$ref": "#/definitions/SemanticConventionBase" }],
 			"properties": {
 				"type": {
 					"type": "string",
@@ -189,27 +165,13 @@
 				}
 			},
 			"anyOf": [
-				{
-					"required": [
-						"prefix"
-					]
-				},
-				{
-					"required": [
-						"name"
-					]
-				}
+				{"required": ["prefix"]},
+				{"required": ["name"]}
 			]
 		},
 		"MetricGroupSemanticConvention": {
-			"allOf": [
-				{
-					"$ref": "#/definitions/SemanticConventionBase"
-				}
-			],
-			"required": [
-				"type"
-			],
+			"allOf": [{ "$ref": "#/definitions/SemanticConventionBase" }],
+			"required": ["type"],
 			"properties": {
 				"type": {
 					"type": "string",
@@ -218,11 +180,7 @@
 			}
 		},
 		"MetricSemanticConvention": {
-			"allOf": [
-				{
-					"$ref": "#/definitions/SemanticConventionBase"
-				}
-			],
+			"allOf": [{ "$ref": "#/definitions/SemanticConventionBase" }],
 			"required": [
 				"type",
 				"metric_name",
@@ -255,22 +213,13 @@
 			}
 		},
 		"SemanticConvention": {
-			"allOf": [
-				{
-					"$ref": "#/definitions/SemanticConventionBase"
-				}
-			],
-			"required": [
-				"type"
-			],
+			"allOf": [{ "$ref": "#/definitions/SemanticConventionBase" }],
+			"required": ["type"],
 			"properties": {
 				"type": {
 					"type": "string",
 					"not": {
-						"enum": [
-							"span",
-							"event"
-						]
+						"enum": ["span", "event"]
 					}
 				}
 			}
@@ -456,14 +405,10 @@
 						},
 						"examples": {
 							"anyOf": [
-								{
-									"$ref": "#/definitions/ValueType"
-								},
+								{ "$ref": "#/definitions/ValueType" },
 								{
 									"type": "array",
-									"items": {
-										"$ref": "#/definitions/ValueType"
-									}
+									"items": { "$ref": "#/definitions/ValueType" }
 								}
 							],
 							"description": "sequence/dictionary of example values for the attribute. They are optional for boolean, int, double, and enum attributes. Example values must be of the same type of the attribute. If only a single example is provided, it can directly be reported without encapsulating it into a sequence/dictionary."

--- a/semantic-conventions/semconv.schema.json
+++ b/semantic-conventions/semconv.schema.json
@@ -9,16 +9,32 @@
 			"items": {
 				"anyOf": [
 					{
-						"allOf": [{"$ref": "#/definitions/SemanticConvention"}]
+						"allOf": [
+							{
+								"$ref": "#/definitions/SemanticConvention"
+							}
+						]
 					},
 					{
-						"allOf": [{"$ref": "#/definitions/SpanSemanticConvention"}]
+						"allOf": [
+							{
+								"$ref": "#/definitions/SpanSemanticConvention"
+							}
+						]
 					},
 					{
-						"allOf": [{"$ref": "#/definitions/EventSemanticConvention"}]
+						"allOf": [
+							{
+								"$ref": "#/definitions/EventSemanticConvention"
+							}
+						]
 					},
 					{
-						"allOf": [{"$ref": "#/definitions/MetricSemanticConvention"}]
+						"allOf": [
+							{
+								"$ref": "#/definitions/MetricSemanticConvention"
+							}
+						]
 					}
 				]
 			}
@@ -133,7 +149,11 @@
 			}
 		},
 		"SpanSemanticConvention": {
-			"allOf": [{ "$ref": "#/definitions/SemanticConventionBase" }],
+			"allOf": [
+				{
+					"$ref": "#/definitions/SemanticConventionBase"
+				}
+			],
 			"properties": {
 				"type": {
 					"type": "string",
@@ -153,7 +173,11 @@
 			}
 		},
 		"EventSemanticConvention": {
-			"allOf": [{ "$ref": "#/definitions/SemanticConventionBase" }],
+			"allOf": [
+				{
+					"$ref": "#/definitions/SemanticConventionBase"
+				}
+			],
 			"properties": {
 				"type": {
 					"type": "string",
@@ -165,13 +189,27 @@
 				}
 			},
 			"anyOf": [
-				{"required": ["prefix"]},
-				{"required": ["name"]}
+				{
+					"required": [
+						"prefix"
+					]
+				},
+				{
+					"required": [
+						"name"
+					]
+				}
 			]
 		},
 		"MetricGroupSemanticConvention": {
-			"allOf": [{ "$ref": "#/definitions/SemanticConventionBase" }],
-			"required": ["type"],
+			"allOf": [
+				{
+					"$ref": "#/definitions/SemanticConventionBase"
+				}
+			],
+			"required": [
+				"type"
+			],
 			"properties": {
 				"type": {
 					"type": "string",
@@ -180,7 +218,11 @@
 			}
 		},
 		"MetricSemanticConvention": {
-			"allOf": [{ "$ref": "#/definitions/SemanticConventionBase" }],
+			"allOf": [
+				{
+					"$ref": "#/definitions/SemanticConventionBase"
+				}
+			],
 			"required": [
 				"type",
 				"metric_name",
@@ -213,13 +255,22 @@
 			}
 		},
 		"SemanticConvention": {
-			"allOf": [{ "$ref": "#/definitions/SemanticConventionBase" }],
-			"required": ["type"],
+			"allOf": [
+				{
+					"$ref": "#/definitions/SemanticConventionBase"
+				}
+			],
+			"required": [
+				"type"
+			],
 			"properties": {
 				"type": {
 					"type": "string",
 					"not": {
-						"enum": ["span", "event"]
+						"enum": [
+							"span",
+							"event"
+						]
 					}
 				}
 			}
@@ -349,7 +400,7 @@
 				{
 					"properties": {
 						"requirement_level": {
-							"description": "specifies the attribute requirement level. Can be 'required', 'conditionally_required', 'recommended', or 'opt_in'. When omitted, the attribute is 'recommended'. When set to 'conditionally_required', the string provided as <condition> MUST specify the conditions under which the attribute is required.",
+							"description": "specifies the attribute requirement level. Can be 'required', 'conditionally_required', 'recommended', or 'opt_in'. When omitted, the attribute is 'recommended'. When set to 'conditionally_required', the string provided MUST specify the conditions under which the attribute is required.",
 							"oneOf": [
 								{
 									"const": "required"
@@ -361,7 +412,7 @@
 										"conditionally_required"
 									],
 									"properties": {
-										"condition": {
+										"conditionally_required": {
 											"type": "string"
 										}
 									}
@@ -405,10 +456,14 @@
 						},
 						"examples": {
 							"anyOf": [
-								{ "$ref": "#/definitions/ValueType" },
+								{
+									"$ref": "#/definitions/ValueType"
+								},
 								{
 									"type": "array",
-									"items": { "$ref": "#/definitions/ValueType" }
+									"items": {
+										"$ref": "#/definitions/ValueType"
+									}
 								}
 							],
 							"description": "sequence/dictionary of example values for the attribute. They are optional for boolean, int, double, and enum attributes. Example values must be of the same type of the attribute. If only a single example is provided, it can directly be reported without encapsulating it into a sequence/dictionary."


### PR DESCRIPTION
The `conditionally_required` option for `requirement_level` has an error in the schema.json. This causes the vscode extension to flag an error when there is none. Here's an example from http-common: 
![image](https://github.com/open-telemetry/build-tools/assets/1909032/ee0cb3a6-6c68-45a6-8fb8-0c07fdacb2e9)

The fix is simply to change the properties to match `conditionally_required`.