### PR TITLE
Inherit overridden attribute properties

### DIFF
--- a/semantic-conventions/src/tests/data/markdown/ref_extends/expected.md
+++ b/semantic-conventions/src/tests/data/markdown/ref_extends/expected.md
@@ -1,0 +1,25 @@
+# Spans
+
+<!-- semconv http.client.spans(full) -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| [`server.address`](input_server.md) | string | Server component of Host header. | `foo` | Required |
+
+Following attributes MUST be provided **at span creation time** (when provided at all), so they can be considered for sampling decisions:
+
+* [`server.address`](input_server.md)
+<!-- endsemconv -->
+
+# Metrics
+
+<!-- semconv http.client.request.duration.metric(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    |
+| -------- | --------------- | ----------- | -------------- |
+| `http.client.request.duration` | Histogram | `s` | Measures request duration. |
+<!-- endsemconv -->
+
+<!-- semconv http.client.request.duration.metric(full) -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| [`server.address`](input_server.md) | string | Server component of Host header. | `foo` | Required |
+<!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/markdown/ref_extends/http.yaml
+++ b/semantic-conventions/src/tests/data/markdown/ref_extends/http.yaml
@@ -1,0 +1,24 @@
+groups:
+  - id: http.client.attributes
+    type: attribute_group
+    brief: 'This document defines semantic conventions for HTTP client attributes.'
+    attributes:
+      - ref: server.address
+        requirement_level: required
+        brief: Server component of Host header.
+
+  - id: http.client.spans
+    type: span
+    brief: 'This document defines semantic conventions for HTTP client Spans.'
+    extends: http.client.attributes
+    attributes:
+      - ref: server.address
+        sampling_relevant: true
+
+  - id: http.client.request.duration.metric
+    type: metric
+    metric_name: http.client.request.duration
+    brief: "Measures request duration."
+    instrument: histogram
+    unit: "s"
+    extends: http.client.attributes

--- a/semantic-conventions/src/tests/data/markdown/ref_extends/input.md
+++ b/semantic-conventions/src/tests/data/markdown/ref_extends/input.md
@@ -1,0 +1,12 @@
+# Spans
+
+<!-- semconv http.client.spans(full) -->
+<!-- endsemconv -->
+
+# Metrics
+
+<!-- semconv http.client.request.duration.metric(metric_table) -->
+<!-- endsemconv -->
+
+<!-- semconv http.client.request.duration.metric(full) -->
+<!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/markdown/ref_extends/input_server.md
+++ b/semantic-conventions/src/tests/data/markdown/ref_extends/input_server.md
@@ -1,0 +1,4 @@
+# General
+
+<!-- semconv server -->
+<!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/markdown/ref_extends/server.yaml
+++ b/semantic-conventions/src/tests/data/markdown/ref_extends/server.yaml
@@ -1,0 +1,10 @@
+groups:
+  - id: server
+    type: attribute_group
+    prefix: server
+    brief: 'This document defines semantic conventions for common server attributes.'
+    attributes:
+      - id: address
+        type: string
+        brief: 'Domain name.'
+        examples: 'foo'

--- a/semantic-conventions/src/tests/semconv/templating/test_markdown.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_markdown.py
@@ -27,6 +27,9 @@ class TestCorrectMarkdown(unittest.TestCase):
     def testRef(self):
         self.check("markdown/ref/")
 
+    def testRefExtends(self):
+        self.check("markdown/ref_extends/")
+
     def testInclude(self):
         self.check("markdown/include/")
 


### PR DESCRIPTION
In some cases, we want to have the following schema:
- `server.address` is a general-purpose attribute defined in `server` conv

```yaml
  - id: server
    prefix: server
    attributes:
      - id: address
        brief: 'Domain name.'
       ....
```
- `http` semconv wants to define it more narrowly. E.g. update a brief or add HTTP-specific note
```yaml
- ref: server.address
  brief: Server component of Host header.
```
- Then HTTP version of this attribute can be used in HTTP traces and metrics.

Today it works only if semconv extends base HTTP one without mentioning the attribute like
```yaml
  - id: http.client.request.duration.metric
    type: metric
    metric_name: http.client.request.duration
   ...
    extends: http.client.attributes
```

Then an attribute is populated from parent semconv as is.

However, if child semconv specifies an attribute even further, it fills it in from the original definition, without considering parent hierarchy first.

I.e. 
```yaml
  - id: http.client.spans
    type: span
   ...
    extends: http.client.attributes
    attributes:
      - ref: server.address
        sampling_relevant: true
```

resolves to 

| Attribute  | Type | Description  | Examples  | Requirement Level |
|---|---|---|---|---|
| [`server.address`](input_server.md) | string | Domain name. | `foo` | Recommended |`

The change implemented here walks up the `extended` hierarchy and fills in properties in the attribute first.