### PR TITLE
Fix referencing template attributes

### DIFF
--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -153,7 +153,7 @@ class BaseSemanticConvention(ValidatableYamlNode):
         )
 
     def contains_attribute(self, attr: "SemanticAttribute"):
-        for local_attr in self.attributes:
+        for local_attr in self.attributes_and_templates:
             if local_attr.attr_id is not None:
                 if local_attr.fqn == attr.fqn:
                     return True
@@ -162,24 +162,26 @@ class BaseSemanticConvention(ValidatableYamlNode):
         return False
 
     def all_attributes(self):
-        return unique_attributes(self.attributes + self.conditional_attributes())
+        return unique_attributes(
+            self.attributes_and_templates + self.conditional_attributes()
+        )
 
     def sampling_attributes(self):
         return unique_attributes(
-            attr for attr in self.attributes if attr.sampling_relevant
+            attr for attr in self.attributes_and_templates if attr.sampling_relevant
         )
 
     def required_attributes(self):
         return unique_attributes(
             attr
-            for attr in self.attributes
+            for attr in self.attributes_and_templates
             if attr.requirement_level == RequirementLevel.REQUIRED
         )
 
     def conditional_attributes(self):
         return unique_attributes(
             attr
-            for attr in self.attributes
+            for attr in self.attributes_and_templates
             if attr.requirement_level == RequirementLevel.CONDITIONALLY_REQUIRED
         )
 
@@ -343,7 +345,7 @@ class SemanticConventionSet:
     def check_unique_fqns(self):
         group_by_fqn: typing.Dict[str, str] = {}
         for model in self.models.values():
-            for attr in model.attributes:
+            for attr in model.attributes_and_templates:
                 if not attr.ref:
                     if attr.fqn in group_by_fqn:
                         self.errors = True
@@ -429,7 +431,7 @@ class SemanticConventionSet:
                     semconv.constraints += (constraint.inherit_anyof(),)
             # Attributes
             parent_attributes = {}
-            for ext_attr in extended.attributes:
+            for ext_attr in extended.attributes_and_templates:
                 parent_attributes[ext_attr.fqn] = ext_attr.inherit_attribute()
             # By induction, parent semconv is already correctly sorted
             parent_attributes.update(
@@ -556,7 +558,7 @@ class SemanticConventionSet:
                     include_semconv, {include_semconv.semconv_id: include_semconv}
                 )
                 attr: SemanticAttribute
-                for attr in include_semconv.attributes:
+                for attr in include_semconv.attributes_and_templates:
                     if semconv.contains_attribute(attr):
                         if self.debug:
                             print(
@@ -585,7 +587,7 @@ class SemanticConventionSet:
             (
                 attr
                 for model in self.models.values()
-                for attr in model.attributes
+                for attr in model.attributes_and_templates
                 if attr.fqn == attr_id and attr.ref is None
             ),
             None,

--- a/semantic-conventions/src/tests/data/markdown/attribute_templates/attribute_templates.yaml
+++ b/semantic-conventions/src/tests/data/markdown/attribute_templates/attribute_templates.yaml
@@ -6,6 +6,7 @@ groups:
     note: >
         These conventions can be used for http and https schemes
         and various HTTP versions like 1.1, 2 and SPDY.
+    extends: general
     attributes:
       - id: request.header
         type: template[string[]]
@@ -19,3 +20,24 @@ groups:
         sampling_relevant: false
         brief: 'HTTP request method.'
         examples: ["GET", "POST", "HEAD"]
+      - ref: referenced_http.request.referenced.header
+  - id: referenced_http_id
+    type: span
+    prefix: referenced_http
+    brief: 'This document defines semantic conventions for HTTP client and server Spans.'
+    attributes:
+      - id: request.referenced.header
+        type: template[string[]]
+        brief: >
+          This is a referenced attribute.
+        examples: '`http.request.header.content_type=["application/json"]`'
+  - id: general
+    type: span
+    prefix: general
+    brief: 'This document defines general attributes.'
+    attributes:
+      - id: some_general_attribute
+        type: template[string]
+        brief: >
+          This is a general attribute.
+        examples: '`some_general_attribute.some_key="abc"`'

--- a/semantic-conventions/src/tests/data/markdown/attribute_templates/expected.md
+++ b/semantic-conventions/src/tests/data/markdown/attribute_templates/expected.md
@@ -1,8 +1,10 @@
 # Custom HTTP Semantic Conventions
 
-<!-- semconv custom_http -->
+<!-- semconv custom_http(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
+| `general.some_general_attribute.<key>` | string | This is a general attribute. | ``some_general_attribute.some_key="abc"`` | Recommended |
 | `custom_http.request.header.<key>` | string[] | HTTP request headers, `<key>` being the normalized HTTP Header name (lowercase, with - characters replaced by _), the value being the header values. | ``http.request.header.content_type=["application/json"]`` | Recommended |
 | `custom_http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
+| `referenced_http.request.referenced.header.<key>` | string[] | This is a referenced attribute. | ``http.request.header.content_type=["application/json"]`` | Recommended |
 <!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/markdown/attribute_templates/expected.md
+++ b/semantic-conventions/src/tests/data/markdown/attribute_templates/expected.md
@@ -3,8 +3,8 @@
 <!-- semconv custom_http(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `general.some_general_attribute.<key>` | string | This is a general attribute. | ``some_general_attribute.some_key="abc"`` | Recommended |
 | `custom_http.request.header.<key>` | string[] | HTTP request headers, `<key>` being the normalized HTTP Header name (lowercase, with - characters replaced by _), the value being the header values. | ``http.request.header.content_type=["application/json"]`` | Recommended |
 | `custom_http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
+| `general.some_general_attribute.<key>` | string | This is a general attribute. | ``some_general_attribute.some_key="abc"`` | Recommended |
 | `referenced_http.request.referenced.header.<key>` | string[] | This is a referenced attribute. | ``http.request.header.content_type=["application/json"]`` | Recommended |
 <!-- endsemconv -->

--- a/semantic-conventions/src/tests/data/markdown/attribute_templates/input.md
+++ b/semantic-conventions/src/tests/data/markdown/attribute_templates/input.md
@@ -1,4 +1,4 @@
 # Custom HTTP Semantic Conventions
 
-<!-- semconv custom_http -->
+<!-- semconv custom_http(full) -->
 <!-- endsemconv -->

--- a/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
+++ b/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
@@ -334,7 +334,7 @@ class TestCorrectParse(unittest.TestCase):
         semconv.finish()
         self.assertEqual(len(semconv.models), 1)
         s = list(semconv.models.values())[0]
-        for attr in s.attributes:
+        for attr in s.attributes_and_templates:
             brief = attr.brief
             self.assertEqual(brief.raw_text, str(brief))
 
@@ -348,11 +348,11 @@ class TestCorrectParse(unittest.TestCase):
 
         client = list(semconv.models.values())[1]
         server = list(semconv.models.values())[2]
-        self.assertIsNotNone(client.attributes[1].ref)
-        self.assertIsNotNone(client.attributes[1].attr_type)
+        self.assertIsNotNone(client.attributes_and_templates[1].ref)
+        self.assertIsNotNone(client.attributes_and_templates[1].attr_type)
 
-        self.assertIsNotNone(server.attributes[1].ref)
-        self.assertIsNotNone(server.attributes[1].attr_type)
+        self.assertIsNotNone(server.attributes_and_templates[1].ref)
+        self.assertIsNotNone(server.attributes_and_templates[1].attr_type)
 
     def test_extends(self):
         semconv = SemanticConventionSet(debug=False)
@@ -458,12 +458,16 @@ class TestCorrectParse(unittest.TestCase):
         semconv.finish()
         self.assertEqual(len(semconv.models), 1)
 
-        self.assertIsNotNone(list(semconv.models.values())[0].attributes[0].deprecated)
+        self.assertIsNotNone(
+            list(semconv.models.values())[0].attributes_and_templates[0].deprecated
+        )
         self.assertEqual(
-            list(semconv.models.values())[0].attributes[0].deprecated,
+            list(semconv.models.values())[0].attributes_and_templates[0].deprecated,
             "Use attribute `nonDepecrated`.",
         )
-        self.assertIsNone(list(semconv.models.values())[0].attributes[3].deprecated)
+        self.assertIsNone(
+            list(semconv.models.values())[0].attributes_and_templates[3].deprecated
+        )
 
     def test_stability(self):
         semconv = SemanticConventionSet(debug=False)
@@ -472,42 +476,42 @@ class TestCorrectParse(unittest.TestCase):
         self.assertEqual(len(semconv.models), 6)
 
         model = list(semconv.models.values())[0]
-        self.assertEqual(len(model.attributes), 4)
+        self.assertEqual(len(model.attributes_and_templates), 4)
         self.assertEqual(model.stability, None)
 
-        attr = model.attributes[0]
+        attr = model.attributes_and_templates[0]
         self.assertEqual(attr.attr_id, "exp_attr")
         self.assertEqual(attr.stability, StabilityLevel.EXPERIMENTAL)
 
-        attr = model.attributes[1]
+        attr = model.attributes_and_templates[1]
         self.assertEqual(attr.attr_id, "stable_attr")
         self.assertEqual(attr.stability, StabilityLevel.STABLE)
 
-        attr = model.attributes[2]
+        attr = model.attributes_and_templates[2]
         self.assertEqual(attr.attr_id, "deprecated_attr")
         self.assertEqual(attr.stability, StabilityLevel.DEPRECATED)
 
-        attr = model.attributes[3]
+        attr = model.attributes_and_templates[3]
         self.assertEqual(attr.attr_id, "def_stability")
         self.assertEqual(attr.stability, StabilityLevel.EXPERIMENTAL)
 
         model = list(semconv.models.values())[1]
-        self.assertEqual(len(model.attributes), 2)
+        self.assertEqual(len(model.attributes_and_templates), 2)
         self.assertEqual(model.stability, StabilityLevel.EXPERIMENTAL)
 
-        attr = model.attributes[0]
+        attr = model.attributes_and_templates[0]
         self.assertEqual(attr.attr_id, "test_attr")
         self.assertEqual(attr.stability, StabilityLevel.EXPERIMENTAL)
 
-        attr = model.attributes[1]
+        attr = model.attributes_and_templates[1]
         self.assertEqual(attr.attr_id, "dep")
         self.assertEqual(attr.stability, StabilityLevel.DEPRECATED)
 
         model = list(semconv.models.values())[2]
-        self.assertEqual(len(model.attributes), 1)
+        self.assertEqual(len(model.attributes_and_templates), 1)
         self.assertEqual(model.stability, StabilityLevel.DEPRECATED)
 
-        attr = model.attributes[0]
+        attr = model.attributes_and_templates[0]
         self.assertEqual(attr.attr_id, "test_attr")
         self.assertEqual(attr.stability, StabilityLevel.DEPRECATED)
 
@@ -546,7 +550,7 @@ class TestCorrectParse(unittest.TestCase):
         models = sorted(semconv.models.values(), key=lambda m: m.semconv_id)
         self.assertEqual(len(models), 6)
         # HTTP
-        attrs = models[0].attributes
+        attrs = models[0].attributes_and_templates
         self.assertEqual(models[0].semconv_id, "http")
         self.assertEqual(len(attrs), 2)
 
@@ -561,7 +565,7 @@ class TestCorrectParse(unittest.TestCase):
         self.assertEqual(attrs[1].ref, "net.peer.port")
 
         # Network
-        attrs = models[1].attributes
+        attrs = models[1].attributes_and_templates
         self.assertEqual(models[1].semconv_id, "network")
         self.assertEqual(len(attrs), 3)
 
@@ -582,7 +586,7 @@ class TestCorrectParse(unittest.TestCase):
         self.assertEqual(attrs[2].ref, None)
 
         # Base - rpc
-        attrs = models[2].attributes
+        attrs = models[2].attributes_and_templates
         self.assertEqual(models[2].semconv_id, "rpc")
         self.assertEqual(len(attrs), 4)
         # Included attributes
@@ -608,7 +612,7 @@ class TestCorrectParse(unittest.TestCase):
         self.assertEqual(attrs[3].ref, None)
 
         # Extended - rpc.client
-        attrs = models[3].attributes
+        attrs = models[3].attributes_and_templates
         self.assertEqual(models[3].semconv_id, "rpc.client")
         self.assertEqual(len(attrs), 6)
         # Parent attributes
@@ -645,7 +649,7 @@ class TestCorrectParse(unittest.TestCase):
         self.assertEqual(attrs[5].ref, None)
 
         # Include on Extended - zother
-        attrs = models[4].attributes
+        attrs = models[4].attributes_and_templates
         self.assertEqual(models[4].semconv_id, "zother")
         self.assertEqual(len(attrs), 1)
         # Defined attributes
@@ -655,7 +659,7 @@ class TestCorrectParse(unittest.TestCase):
         self.assertEqual(attrs[0].ref, None)
 
         # Include on Extended - zz.rpc.client
-        attrs = models[5].attributes
+        attrs = models[5].attributes_and_templates
         self.assertEqual(models[5].semconv_id, "zz.rpc.client")
         self.assertEqual(len(attrs), 8)
         # Parent attributes


### PR DESCRIPTION
In https://github.com/open-telemetry/build-tools/pull/186 there was an oversight that template-type attributes cannot be referenced in other semantic conventions.

This PR fixes this bug and extends the corresponding test with a referenced template attribute.

