### PR TITLE
Update semantic-conventions Directory to Support PyPi Packaging

### DIFF
--- a/semantic-conventions/README.rst
+++ b/semantic-conventions/README.rst
@@ -1,0 +1,16 @@
+OpenTelemetry Semantic Convention Utility Tools
+===============================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-semconvgen.svg
+   :target: https://pypi.org/project/opentelemetry-semconvgen/
+
+This library is provided as a convenience to access the OpenTelemetry Semantic Convention Generator, and semantic convention syntax parsing.
+
+Installation
+------------
+
+::
+
+     pip install opentelemetry-semconvgen

--- a/semantic-conventions/setup.cfg
+++ b/semantic-conventions/setup.cfg
@@ -13,15 +13,15 @@
 # limitations under the License.
 #
 [metadata]
-name = semconvgen
-description = OpenTelemetry Semantic Conventions utility
+name = opentelemetry-semconvgen
+description = OpenTelemetry Semantic Conventions Utilities
 author = The OpenTelemetry Authors
 author_email = cncf-opentelemetry-contributors@lists.cncf.io
-url = https://github.com/dynatrace-oss-contrib/build-tools/
+url = https://github.com/open-telemetry/build-tools
 platforms = any
 license = Apache-2.0
 classifiers =
-    Development Status :: 1 - Alpha
+    Development Status :: 3 - Alpha
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
@@ -36,10 +36,10 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    dataclasses~=0.6
+    dataclasses~=0.6;python_version<'3.7'
     ruamel.yaml~=0.16
     Jinja2~=3.0
-    mistune==2.0.0a6
+    mistune==2.0.0
 
 [options.packages.find]
 where = src

--- a/semantic-conventions/setup.py
+++ b/semantic-conventions/setup.py
@@ -14,8 +14,16 @@ with open(VERSION_FILENAME, encoding="utf-8") as f:
 VERSION_SUFFIX = os.environ.get("SEMCONGEN_VERSION_SUFFIX")
 PUBLIC_VERSION = PACKAGE_INFO["__version__"]
 
+# long description
+README_FILENAME = os.path.join(BASE_DIR, "README.rst")
+LONG_DESCRIPTION = ""
+with open(README_FILENAME, encoding="utf-8") as f:
+    LONG_DESCRIPTION = f.read()
+
 setuptools.setup(
     version=PUBLIC_VERSION
     if not VERSION_SUFFIX
-    else PUBLIC_VERSION + "+" + VERSION_SUFFIX
+    else PUBLIC_VERSION + "+" + VERSION_SUFFIX,
+    long_description=LONG_DESCRIPTION,
+    long_description_content_type="text/x-rst",
 )


### PR DESCRIPTION
## Description
There are some cases where using the SemanticConvention model outside of a CLI would be useful, such as third-party scripts that perform validation on Semantics on top of the standard syntax validation found in the semconvgen models. That said, adding the package to PyPi makes it easily available for other applications/services to reference it as a dependency. In this PR, a description and package name is edited to allow easy publishing to PyPi.

## Issue
https://github.com/open-telemetry/build-tools/issues/253

## Testing
- [x] Tested publishing the library on PyPi's test server
- [x] Tested running pip install within a venv to install the library

## Steps to Publish
1. Obtain information needed from opentelemetry's PyPi account (API Token) [[more information](https://packaging.python.org/en/latest/tutorials/packaging-projects/#next-steps)]
2. Go to the `semantic-conventions` directory
```bash
cd semantic-conventions
```
3. Install dependencies
```bash
python -m pip install --upgrade pip
pip install --upgrade setuptools wheel twine
```
4. Generate the wheels (distribution) (Note when they are asking for username/password, it should be as follows: 
"**\_\_token\_\_"/{OPENTELEMETRY_ACCOUNT_API_TOKEN}**)
```bash
pip wheel --no-deps . --wheel-dir ./dist
```

5. Upload the distribution
```bash
python3 -m twine upload --repository testpypi dist/* --verbose
```
