### PR TITLE
Allow --output to be templatized when generating multiple files.

### DIFF
--- a/semantic-conventions/README.md
+++ b/semantic-conventions/README.md
@@ -119,13 +119,36 @@ By default, all models are fed into the specified template at once, i.e. only a 
 This is helpful to generate constants for the semantic attributes, [example from opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java/tree/main/buildscripts/semantic-convention).
 
 If the parameter `--file-per-group {pattern}` is set, a single yaml model is fed into the template
-and the value of `pattern` is resolved from the model and attached as prefix to the output argument.
+and the value of `pattern` is resolved from the model and may be used in the output argument.
 This way, multiple files are generated. The value of `pattern` can be one of the following:
 
 - `semconv_id`: The id of the semantic convention.
 - `prefix`: The prefix with which all attributes starts with.
 - `extends`: The id of the parent semantic convention.
 - `root_namespace`: The root namespace of attribute to group by.
+
+The `--output` parameter, when `--file-per-group` is used is evaluated as a template. The following variables are provided to output:
+
+- `prefix`: A prefix name for files, determined from the grouping. e.g. `http`, `database`, `user-agent`.
+- `pascal_prefix`: A Pascal-case prefix name for files. e.g. `Http`, `Database`, `UserAgent`.
+- `camel_prefix`: A camel-case prefix name for files. e.g. `http`, `database`, `userAgent`.
+- `snake_prefix`: A snake-case prefix name for files. e.g. `http`, `database`, `user_agent`.
+
+For example, you could do the following:
+
+```bash
+docker run --rm \
+  -v ${SCRIPT_DIR}/opentelemetry-specification/semantic_conventions/trace:/source \
+  -v ${SCRIPT_DIR}/templates:/templates \
+  -v ${ROOT_DIR}/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/:/output \
+  otel/semconvgen:$GENERATOR_VERSION \
+  --yaml-root /source \
+  code \
+  --template /templates/SemanticAttributes.java.j2 \
+  --file-per-group root_namespace \
+  --output "/output/{{pascal_prefix}}Attributes.java" \
+  ...other parameters...
+```
 
 Finally, additional value can be passed to the template in form of `key=value` pairs separated by
 comma using the `--parameters [{key=value},]+` or `-D` flag.

--- a/semantic-conventions/src/opentelemetry/semconv/templating/code.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/code.py
@@ -162,6 +162,11 @@ def to_camelcase(name: str, first_upper=False) -> str:
         first = first.capitalize()
     return first + "".join(word.capitalize() for word in rest)
 
+def to_snake_case(name):
+    name = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+    name = re.sub('__([A-Z])', r'_\1', name)
+    name = re.sub('([a-z0-9])([A-Z])', r'\1_\2', name)
+    return name.lower()
 
 def first_up(name: str) -> str:
     return name[0].upper() + name[1:]
@@ -265,22 +270,20 @@ class CodeRenderer:
 
     @staticmethod
     def prefix_output_file(env, file_name, prefix):
-        # TODO - We treat incoming file names as a pattern.
+        # We treat incoming file names as a pattern.
         # We allow will give them access to the same jinja model as file creation
         # and we'll make sure a few things are available there, specifically:
-        # camelcase_file_name, raw_file_name, ...
+        # pascal case, camel case and snake case
         data={
             "prefix": prefix,
-            "camelcase_prefix": to_camelcase(prefix, True),
-            # TODO Pascal version
-            # TODO snake_case
+            "pascal_prefix": to_camelcase(prefix, True),
+            "camel_prefix": to_camelcase(prefix, False),
+            "snake_prefix": to_snake_case(prefix),
         }
-        print("[JOSH] Creating filename [", file_name, "] with data: ", data, "\n")
         template = env.from_string(file_name)
         full_name = template.render(data)
         dirname = os.path.dirname(full_name)
         basename = os.path.basename(full_name)
-        print("[JOSH] Writing to file: ", os.path.join(dirname, basename), "\n")
         return os.path.join(dirname, basename)
 
     def render(

--- a/semantic-conventions/src/opentelemetry/semconv/templating/code.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/code.py
@@ -264,10 +264,24 @@ class CodeRenderer:
         env.lstrip_blocks = trim_whitespace
 
     @staticmethod
-    def prefix_output_file(file_name, prefix):
-        basename = os.path.basename(file_name)
-        dirname = os.path.dirname(file_name)
-        return os.path.join(dirname, to_camelcase(prefix, True) + basename)
+    def prefix_output_file(env, file_name, prefix):
+        # TODO - We treat incoming file names as a pattern.
+        # We allow will give them access to the same jinja model as file creation
+        # and we'll make sure a few things are available there, specifically:
+        # camelcase_file_name, raw_file_name, ...
+        data={
+            "prefix": prefix,
+            "camelcase_prefix": to_camelcase(prefix, True),
+            # TODO Pascal version
+            # TODO snake_case
+        }
+        print("[JOSH] Creating filename [", file_name, "] with data: ", data, "\n")
+        template = env.from_string(file_name)
+        full_name = template.render(data)
+        dirname = os.path.dirname(full_name)
+        basename = os.path.basename(full_name)
+        print("[JOSH] Writing to file: ", os.path.join(dirname, basename), "\n")
+        return os.path.join(dirname, basename)
 
     def render(
         self,
@@ -307,7 +321,7 @@ class CodeRenderer:
     ):
         for semconv in semconvset.models.values():
             prefix = getattr(semconv, pattern)
-            output_name = self.prefix_output_file(output_file, prefix)
+            output_name = self.prefix_output_file(env, output_file, prefix)
             data = self.get_data_multiple_files(semconv, template_path)
             template = env.get_template(file_name, globals=data)
             self._write_template_to_file(template, data, output_name)
@@ -324,7 +338,7 @@ class CodeRenderer:
         metrics = self._grouped_metric_definitions(semconvset)
         for ns, attribute_and_templates in attribute_and_templates.items():
             sanitized_ns = ns if ns != "" else "other"
-            output_name = self.prefix_output_file(output_file, sanitized_ns)
+            output_name = self.prefix_output_file(env, output_file, sanitized_ns)
 
             data = {
                 "template": template_path,

--- a/semantic-conventions/src/opentelemetry/semconv/templating/code.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/code.py
@@ -162,11 +162,13 @@ def to_camelcase(name: str, first_upper=False) -> str:
         first = first.capitalize()
     return first + "".join(word.capitalize() for word in rest)
 
+
 def to_snake_case(name):
-    name = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
-    name = re.sub('__([A-Z])', r'_\1', name)
-    name = re.sub('([a-z0-9])([A-Z])', r'\1_\2', name)
+    name = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
+    name = re.sub("__([A-Z])", r"_\1", name)
+    name = re.sub("([a-z0-9])([A-Z])", r"\1_\2", name)
     return name.lower()
+
 
 def first_up(name: str) -> str:
     return name[0].upper() + name[1:]
@@ -274,7 +276,7 @@ class CodeRenderer:
         # We allow will give them access to the same jinja model as file creation
         # and we'll make sure a few things are available there, specifically:
         # pascal case, camel case and snake case
-        data={
+        data = {
             "prefix": prefix,
             "pascal_prefix": to_camelcase(prefix, True),
             "camel_prefix": to_camelcase(prefix, False),

--- a/semantic-conventions/src/tests/semconv/templating/test_code.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_code.py
@@ -79,7 +79,7 @@ def test_codegen_attribute_root_ns(test_file_path, read_test_file):
     renderer.render(
         semconv,
         template_path,
-        os.path.join(tmppath, "{{camelcase_prefix}}Attributes.java"),
+        os.path.join(tmppath, "{{pascal_prefix}}Attributes.java"),
         "root_namespace",
     )
 
@@ -91,6 +91,33 @@ def test_codegen_attribute_root_ns(test_file_path, read_test_file):
 
     third = read_test_file("jinja", test_path, "ThirdAttributes.java")
     check_file(tmppath, "ThirdAttributes.java", third)
+
+def test_codegen_attribute_root_ns_snake_case_file(test_file_path, read_test_file):
+    semconv = SemanticConventionSet(debug=False)
+
+    semconv.parse(test_file_path("jinja", "group_by_root_namespace", "attributes.yml"))
+    semconv.finish()
+
+    template_path = test_file_path("jinja", "group_by_root_namespace", "template_all")
+    renderer = CodeRenderer({}, trim_whitespace=True)
+
+    test_path = os.path.join("group_by_root_namespace", "all")
+    tmppath = tempfile.mkdtemp()
+    renderer.render(
+        semconv,
+        template_path,
+        os.path.join(tmppath, "{{snake_prefix}}_attributes.java"),
+        "root_namespace",
+    )
+
+    first = read_test_file("jinja", test_path, "FirstAttributes.java")
+    check_file(tmppath, "first_attributes.java", first)
+
+    second = read_test_file("jinja", test_path, "SecondAttributes.java")
+    check_file(tmppath, "second_attributes.java", second)
+
+    third = read_test_file("jinja", test_path, "ThirdAttributes.java")
+    check_file(tmppath, "third_attributes.java", third)
 
 
 def test_codegen_attribute_root_ns_stable(test_file_path, read_test_file):
@@ -106,7 +133,7 @@ def test_codegen_attribute_root_ns_stable(test_file_path, read_test_file):
     renderer.render(
         semconv,
         template_path,
-        os.path.join(tmppath, "{{camelcase_prefix}}Attributes.java"),
+        os.path.join(tmppath, "{{pascal_prefix}}Attributes.java"),
         "root_namespace",
     )
 
@@ -130,7 +157,7 @@ def test_codegen_attribute_root_ns_no_group_prefix(test_file_path, read_test_fil
     renderer.render(
         semconv,
         template_path,
-        os.path.join(tmppath, "{{camelcase_prefix}}Attributes.java"),
+        os.path.join(tmppath, "{{pascal_prefix}}Attributes.java"),
         "root_namespace",
     )
 
@@ -170,7 +197,7 @@ def test_codegen_attribute_root_ns_metrics(test_file_path, read_test_file):
 
     tmppath = tempfile.mkdtemp()
     renderer.render(
-        semconv, template_path, os.path.join(tmppath, "{{camelcase_prefix}}.java"), "root_namespace"
+        semconv, template_path, os.path.join(tmppath, "{{pascal_prefix}}.java"), "root_namespace"
     )
 
     first = read_test_file("jinja", test_path, "First.java")

--- a/semantic-conventions/src/tests/semconv/templating/test_code.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_code.py
@@ -92,6 +92,7 @@ def test_codegen_attribute_root_ns(test_file_path, read_test_file):
     third = read_test_file("jinja", test_path, "ThirdAttributes.java")
     check_file(tmppath, "ThirdAttributes.java", third)
 
+
 def test_codegen_attribute_root_ns_snake_case_file(test_file_path, read_test_file):
     semconv = SemanticConventionSet(debug=False)
 
@@ -197,7 +198,10 @@ def test_codegen_attribute_root_ns_metrics(test_file_path, read_test_file):
 
     tmppath = tempfile.mkdtemp()
     renderer.render(
-        semconv, template_path, os.path.join(tmppath, "{{pascal_prefix}}.java"), "root_namespace"
+        semconv,
+        template_path,
+        os.path.join(tmppath, "{{pascal_prefix}}.java"),
+        "root_namespace",
     )
 
     first = read_test_file("jinja", test_path, "First.java")

--- a/semantic-conventions/src/tests/semconv/templating/test_code.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_code.py
@@ -79,7 +79,7 @@ def test_codegen_attribute_root_ns(test_file_path, read_test_file):
     renderer.render(
         semconv,
         template_path,
-        os.path.join(tmppath, "Attributes.java"),
+        os.path.join(tmppath, "{{camelcase_prefix}}Attributes.java"),
         "root_namespace",
     )
 
@@ -106,7 +106,7 @@ def test_codegen_attribute_root_ns_stable(test_file_path, read_test_file):
     renderer.render(
         semconv,
         template_path,
-        os.path.join(tmppath, "Attributes.java"),
+        os.path.join(tmppath, "{{camelcase_prefix}}Attributes.java"),
         "root_namespace",
     )
 
@@ -130,7 +130,7 @@ def test_codegen_attribute_root_ns_no_group_prefix(test_file_path, read_test_fil
     renderer.render(
         semconv,
         template_path,
-        os.path.join(tmppath, "Attributes.java"),
+        os.path.join(tmppath, "{{camelcase_prefix}}Attributes.java"),
         "root_namespace",
     )
 
@@ -170,7 +170,7 @@ def test_codegen_attribute_root_ns_metrics(test_file_path, read_test_file):
 
     tmppath = tempfile.mkdtemp()
     renderer.render(
-        semconv, template_path, os.path.join(tmppath, ".java"), "root_namespace"
+        semconv, template_path, os.path.join(tmppath, "{{camelcase_prefix}}.java"), "root_namespace"
     )
 
     first = read_test_file("jinja", test_path, "First.java")


### PR DESCRIPTION
Related to #242 - "File names should follow per-language pattern"

When outputting multiple files, we allow `--output` to be evaluated as its own jinja template.   This template would have the following values:

- `prefix`
- `pascal_prefix`
- `camel_prefix`
- `snake_prefix`

This should allow language authors to customize filenames as they need for language conventions.