### PR TITLE
Add metrics to the context of non-scoped codegen

### DIFF
--- a/semantic-conventions/README.md
+++ b/semantic-conventions/README.md
@@ -171,9 +171,10 @@ Processes all parsed semantic conventions
 - `semconvs` - the dictionary containing parsed `BaseSemanticConvention` instances with semconv `id` as a key
 - `attributes_and_templates` - the dictionary containing all attributes (including template ones) grouped by their root namespace.
   Each element in the dictionary is a list of attributes that share the same root namespace. Attributes that don't have a namespace
-  appear under `""` key.
+  appear under `""` key. Attributes and templates are sorted by attribute name.
 - `attributes` - the list of all attributes from all parsed semantic conventions. Does not include template attributes.
 - `attribute_templates` - the list of all attribute templates from all parsed semantic conventions.
+- `metrics` - the list of all metric semantic conventions sorted by metric name.
 
 #### The `root_namespace` pattern
 

--- a/semantic-conventions/src/opentelemetry/semconv/templating/code.py
+++ b/semantic-conventions/src/opentelemetry/semconv/templating/code.py
@@ -233,6 +233,7 @@ class CodeRenderer:
             "attributes": semconvset.attributes(),
             "attribute_templates": semconvset.attribute_templates(),
             "attributes_and_templates": self._grouped_attribute_definitions(semconvset),
+            "metrics": self._all_metrics_definitions(semconvset) or []
         }
         data.update(self.parameters)
         return data
@@ -386,6 +387,16 @@ class CodeRenderer:
                 grouped_metrics[ns], key=lambda a: a.metric_name
             )
         return grouped_metrics
+
+    def _all_metrics_definitions(self, semconvset):
+        all_metrics = []
+        for semconv in semconvset.models.values():
+            if not is_metric(semconv):
+                continue
+
+            all_metrics.append(semconv)
+
+        return sorted(all_metrics, key=lambda a: a.metric_name)
 
     def _write_template_to_file(self, template, data, output_name):
         template.globals["now"] = datetime.datetime.utcnow()

--- a/semantic-conventions/src/tests/data/jinja/metrics/expected_metrics.java
+++ b/semantic-conventions/src/tests/data/jinja/metrics/expected_metrics.java
@@ -1,0 +1,16 @@
+class AllMetrics {
+  /**
+  * first metric description
+  * Unit: {one}
+  * Instrument: counter
+  * Experimental: False
+  */
+  public static final String FIRST_METRIC = "first.metric";
+  /**
+  * second metric description
+  * Unit: s
+  * Instrument: histogram
+  * Experimental: True
+  */
+  public static final String SECOND_GROUP_METRIC = "second_group.metric";
+}

--- a/semantic-conventions/src/tests/data/jinja/metrics/metrics_template
+++ b/semantic-conventions/src/tests/data/jinja/metrics/metrics_template
@@ -1,0 +1,11 @@
+class AllMetrics {
+{%- for metric in metrics %}
+  /**
+  * {{metric.brief | to_doc_brief}}
+  * Unit: {{ metric.unit }}
+  * Instrument: {{ metric.instrument }}
+  * Experimental: {{ metric | is_experimental }}
+  */
+  public static final String {{ metric.metric_name | to_const_name }} = "{{metric.metric_name}}";
+{%- endfor %}
+}

--- a/semantic-conventions/src/tests/data/yaml/metrics/metrics.yaml
+++ b/semantic-conventions/src/tests/data/yaml/metrics/metrics.yaml
@@ -1,0 +1,30 @@
+groups:
+  - id: first_group_id
+    type: attribute_group
+    brief: first description
+    prefix: first
+    attributes:
+      - id: attr_one
+        type: boolean
+        brief: short description of attr_one
+
+  - id: first_metric_id
+    brief: first metric description
+    metric_name: first.metric
+    instrument: counter
+    type: metric
+    unit: "{one}"
+    stability: stable
+    extends: first_group_id
+
+  - id: second_group_id
+    brief: second metric description
+    metric_name: second_group.metric
+    type: metric
+    instrument: histogram
+    unit: "s"
+    prefix: second_group
+    attributes:
+      - id: attr_two
+        type: int
+        brief: short description of attr_two

--- a/semantic-conventions/src/tests/semconv/templating/test_code.py
+++ b/semantic-conventions/src/tests/semconv/templating/test_code.py
@@ -22,6 +22,22 @@ def test_codegen_units(test_file_path, read_test_file):
 
     assert result == expected
 
+def test_codegen_metrics_all(test_file_path, read_test_file):
+    semconv = SemanticConventionSet(debug=False)
+    semconv.parse(test_file_path("yaml", "metrics", "metrics.yaml"))
+    semconv.finish()
+
+    template_path = test_file_path("jinja", "metrics", "metrics_template")
+    renderer = CodeRenderer({}, trim_whitespace=False)
+
+    filename = os.path.join(tempfile.mkdtemp(), "AllMetrics.java")
+    renderer.render(semconv, template_path, filename, None)
+    with open(filename, "r", encoding="utf-8") as f:
+        result = f.read()
+
+    expected = read_test_file("jinja", "metrics", "expected_metrics.java")
+
+    assert result == expected
 
 def test_strip_blocks_enabled(test_file_path, read_test_file):
     """Tests that the Jinja whitespace control params are fed to the Jinja environment"""


### PR DESCRIPTION
Before:
`{% for id in semconvs %}{%- if semconvs[id].GROUP_TYPE_NAME == 'metric' %}{% set metric = semconvs[id] %}`

after 

`{%- for metric in metrics %}`