### PR TITLE
Added display_name as an allowed property on semconv attribute groups

### DIFF
--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_convention.py
@@ -112,6 +112,7 @@ class BaseSemanticConvention(ValidatableYamlNode):
         "attributes",
         "constraints",
         "deprecated",
+        "display_name",
     )
 
     GROUP_TYPE_NAME: str


### PR DESCRIPTION
Fixes checks for https://github.com/open-telemetry/semantic-conventions/pull/985