### PR TITLE
Attribute naming collisions and resolution

### DIFF
--- a/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/semantic_attribute.py
@@ -22,6 +22,7 @@ from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
 from opentelemetry.semconv.model.utils import (
     check_no_missing_keys,
+    to_code_const_name,
     validate_id,
     validate_values,
 )
@@ -59,6 +60,7 @@ class SemanticAttribute:
     note: str
     position: List[int]
     root_namespace: str
+    code_const_name: str
     inherited: bool = False
     imported: bool = False
 
@@ -231,6 +233,7 @@ class SemanticAttribute:
                 note=parsed_note,
                 position=position,
                 root_namespace=root_namespace,
+                code_const_name=to_code_const_name(fqn),
             )
             if attr.fqn in attributes:
                 position = position_data[list(attribute)[0]]

--- a/semantic-conventions/src/opentelemetry/semconv/model/utils.py
+++ b/semantic-conventions/src/opentelemetry/semconv/model/utils.py
@@ -51,6 +51,8 @@ def check_no_missing_keys(yaml, mandatory, validation_ctx):
         msg = f"Missing keys: {missing}"
         validation_ctx.raise_or_warn(position, msg, yaml.get("id"))
 
+def to_code_const_name(name: str) -> str:
+    return name.upper().replace(".", "_")
 
 class ValidatableYamlNode:
 

--- a/semantic-conventions/src/tests/data/jinja/group_by_root_namespace/attributes_and_metrics/SecondGroup.java
+++ b/semantic-conventions/src/tests/data/jinja/group_by_root_namespace/attributes_and_metrics/SecondGroup.java
@@ -6,7 +6,7 @@ class SecondGroup {
   /**
   * short description of attr_two
   */
-  public static final AttributeKey<Long> SECOND_GROUP_ATTR_TWO = longKey("second_group.attr_two");
+  public static final AttributeKey<Long> SECOND_GROUP_ATTR_TWO = longKey("second_group.attr.two");
   /**
   * second metric description
   * Experimental: True

--- a/semantic-conventions/src/tests/data/jinja/group_by_root_namespace/attributes_and_metrics/semconv.yml
+++ b/semantic-conventions/src/tests/data/jinja/group_by_root_namespace/attributes_and_metrics/semconv.yml
@@ -30,4 +30,9 @@ groups:
       - id: attr_two
         type: int
         stability: experimental
+        brief: short description of attr_two - this should not be rendered to code.
+        deprecated: "Replaced by `second_group_id.attr.two`"
+      - id: attr.two
+        type: int
+        stability: experimental
         brief: short description of attr_two

--- a/semantic-conventions/src/tests/data/yaml/deprecated/name_collisions_const_deprecated.yaml
+++ b/semantic-conventions/src/tests/data/yaml/deprecated/name_collisions_const_deprecated.yaml
@@ -1,0 +1,29 @@
+groups:
+  - id: code_const.collision
+    type: attribute_group
+    brief: "Code constant collision test"
+    attributes:
+      - id: foo.bar
+        type: string
+        brief: ""
+        stability: experimental
+        examples: ["foo"]
+      - id: foo_bar
+        type: string
+        brief: ""
+        deprecated: "Replaced by `foo.bar`"
+        stability: experimental
+        examples: ["bar"]
+      - id: another_foo.bar
+        type: string
+        brief: ""
+        stability: experimental
+        deprecated: "Replaced by `another_foo_bar`"
+        examples: ["foo"]
+      - id: another_foo_bar
+        type: string
+        brief: ""
+        stability: experimental
+        examples: ["bar"]
+
+

--- a/semantic-conventions/src/tests/data/yaml/deprecated/name_collisions_with_namespace_deprecated.yaml
+++ b/semantic-conventions/src/tests/data/yaml/deprecated/name_collisions_with_namespace_deprecated.yaml
@@ -1,0 +1,28 @@
+groups:
+  - id: namespace.collision
+    type: attribute_group
+    brief: "Namespace collision test"
+    attributes:
+      - id: foo.bar
+        type: string
+        brief: ""
+        stability: experimental
+        examples: ["foo"]
+      - id: foo.bar.baz
+        type: string
+        brief: ""
+        stability: experimental
+        examples: ["bar"]
+        deprecated: "Replaced by `foo.bar`"
+      - id: another_foo.bar
+        type: string
+        brief: ""
+        stability: experimental
+        examples: ["foo"]
+        deprecated: "Replaced by `another_foo.bar.*`"
+      - id: another_foo.bar.baz
+        type: string
+        brief: ""
+        stability: experimental
+        examples: ["bar"]
+

--- a/semantic-conventions/src/tests/data/yaml/errors/name_collisions_const.yaml
+++ b/semantic-conventions/src/tests/data/yaml/errors/name_collisions_const.yaml
@@ -1,0 +1,17 @@
+groups:
+  - id: code_const.collision
+    type: attribute_group
+    brief: "Code constant collision test"
+    attributes:
+      - id: foo.bar
+        type: string
+        brief: ""
+        stability: experimental
+        examples: ["foo"]
+      - id: foo_bar
+        type: string
+        brief: ""
+        stability: experimental
+        examples: ["bar"]
+
+

--- a/semantic-conventions/src/tests/data/yaml/errors/name_collisions_with_namespace.yaml
+++ b/semantic-conventions/src/tests/data/yaml/errors/name_collisions_with_namespace.yaml
@@ -1,0 +1,17 @@
+groups:
+  - id: namespace.collision
+    type: attribute_group
+    brief: "Namespace collision test"
+    attributes:
+      - id: foo.bar
+        type: string
+        brief: ""
+        stability: experimental
+        examples: ["foo"]
+      - id: foo.bar.baz
+        type: string
+        brief: ""
+        stability: experimental
+        examples: ["bar"]
+
+

--- a/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
+++ b/semantic-conventions/src/tests/semconv/model/test_correct_parse.py
@@ -23,6 +23,7 @@ from opentelemetry.semconv.model.semantic_convention import (
     SemanticConventionSet,
     SpanSemanticConvention,
 )
+from opentelemetry.semconv.model.utils import ValidationContext
 
 
 class TestCorrectParse(unittest.TestCase):
@@ -640,6 +641,20 @@ class TestCorrectParse(unittest.TestCase):
         self.assertEqual(attrs[3].imported, False)
         self.assertEqual(attrs[3].inherited, True)
         self.assertEqual(attrs[3].ref, None)
+
+    def test_namespace_collision_deprecated(self):
+        file = "yaml/deprecated/name_collisions_with_namespace_deprecated.yaml"
+        semconv = SemanticConventionSet(False)
+        semconv.parse(self.load_file(file), ValidationContext(file, True))
+        semconv.finish()
+        self.assertFalse(semconv.has_error())
+
+    def test_const_collision_deprecated(self):
+        file = "yaml/deprecated/name_collisions_const_deprecated.yaml"
+        semconv = SemanticConventionSet(False)
+        semconv.parse(self.load_file(file), ValidationContext(file, True))
+        semconv.finish()
+        self.assertFalse(semconv.has_error())
 
     def semantic_convention_check(self, s, expected):
         self.assertEqual(expected["prefix"], s.prefix)

--- a/semantic-conventions/src/tests/semconv/model/test_error_detection.py
+++ b/semantic-conventions/src/tests/semconv/model/test_error_detection.py
@@ -531,6 +531,20 @@ class TestCorrectErrorDetection(unittest.TestCase):
         self.assertIn("multiple requirement_level values are not allowed!", msg)
         self.assertEqual(e.line, 12)
 
+    def test_namespace_collision(self):
+        file = "yaml/errors/name_collisions_with_namespace.yaml"
+        semconv = SemanticConventionSet(False)
+        semconv.parse(self.load_file(file), ValidationContext(file, True))
+        semconv.finish()
+        self.assertTrue(semconv.has_error())
+
+    def test_const_collision(self):
+        file = "yaml/errors/name_collisions_const.yaml"
+        semconv = SemanticConventionSet(False)
+        semconv.parse(self.load_file(file), ValidationContext(file, True))
+        semconv.finish()
+        self.assertTrue(semconv.has_error())
+
     def open_yaml(self, path):
         with open(self.load_file(path), encoding="utf-8") as file:
             return parse_semantic_convention_groups(file, ValidationContext(path, True))


### PR DESCRIPTION
Adds check for naming conflicts:
1. Code generation (https://github.com/open-telemetry/semantic-conventions/issues/1118)
   - fails when 2+ non-deprecated attributes would result in the same const name in code 
   - allows to have a deprecated and non-deprecated attribute with the same const name
2. Namespace vs name collision (https://github.com/open-telemetry/semantic-conventions/issues/1068)
   - fails when a non-deprecated attribute collides with a namespace of a non-deprecated attribute
   - allows collisions if one of them is deprecated

