### PR TITLE
Simplify dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,23 +4,21 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
   - package-ecosystem: "docker"
-    directory: "/protobuf"
+    directories:
+      - "**/*"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "docker"
-    directory: "/schemas"
-    schedule:
-      interval: "weekly"
+
   - package-ecosystem: "gomod"
-    directory: "/schemas"
+    directories:
+      - "**/*"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "docker"
-    directory: "/semantic-conventions"
-    schedule:
-      interval: "weekly"
+
   - package-ecosystem: "pip"
-    directory: "/semantic-conventions"
+    directories:
+      - "**/*"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Dependabot now supports wildcard and we can simplify the config by making it search in all the directories automatically.