### PR TITLE
Remove parquet from the protobuf build image

### DIFF
--- a/protobuf/Dockerfile
+++ b/protobuf/Dockerfile
@@ -10,7 +10,6 @@ ARG GRPC_JAVA_VERSION=1.51.3
 ARG PROTOC_GEN_GOGO_VERSION=b03c65ea87cdc3521ede29f62fe3ce239267c1bc
 ARG PROTOC_GEN_LINT_VERSION=0.3.0
 ARG GRPC_GATEWAY_VERSION=2.15.0
-ARG PROTOC_GEN_PARQUET_VERSION=0.4.3
 ARG UPX_VERSION=4.0.2
 
 ARG TARGETARCH=amd64
@@ -120,15 +119,6 @@ RUN mkdir -p ${GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway && \
     install -Ds /grpc-gateway-out/protoc-gen-openapiv2 /out/usr/bin/protoc-gen-openapiv2 && \
     mkdir -p /out/usr/include/protoc-gen-openapiv2/options && \
     install -D $(find ./protoc-gen-openapiv2/options -name '*.proto') -t /out/usr/include/protoc-gen-openapiv2/options
-
-ARG PROTOC_GEN_PARQUET_VERSION
-RUN mkdir -p ${GOPATH}/src/github.com/atoulme/protoc-gen-parquet && \
-    curl -sSL https://api.github.com/repos/atoulme/protoc-gen-parquet/tarball/v${PROTOC_GEN_PARQUET_VERSION} | tar xz --strip 1 -C ${GOPATH}/src/github.com/atoulme/protoc-gen-parquet && \
-    cd ${GOPATH}/src/github.com/atoulme/protoc-gen-parquet && \
-    go build -ldflags '-w -s' -o bin/protoc-gen-parquet . && \
-    install -Ds bin/protoc-gen-parquet /out/usr/bin/protoc-gen-parquet && \
-    mkdir -p /out/usr/include/protoc-gen-parquet/options && \
-    install -D $(find ./parquet_options -name '*.proto') -t /out/usr/include/protoc-gen-parquet/options
 
 FROM alpine:3.18 as packer
 RUN apk add --no-cache curl


### PR DESCRIPTION
Parquet never landed as part of the protobuf code generation ; time to remove it.