### PR TITLE
Update CODEOWNERS to reflect new team handle

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,4 +13,4 @@
 #
 
 # Global owners, will be the owners for everything in the repo. Membership is tracked via https://github.com/open-telemetry/community/blob/main/community-members.md#specifications-and-proto
-*   @open-telemetry/specs-approvers
+*   @open-telemetry/spec-sponsors


### PR DESCRIPTION
Fixes:

```
CODEOWNERS errors
Unknown owner on line 16: make sure the team @open-telemetry/specs-approvers exists, is publicly visible, and has write access to the repository
*   @open-telemetry/specs-approvers
```