### PR TITLE
Prepare v0.26.0 release

### DIFF
--- a/schemas/CHANGELOG.md
+++ b/schemas/CHANGELOG.md
@@ -4,6 +4,13 @@ Please update the changelog as part of any significant pull request.
 
 ## Unreleased
 
+## v0.26.0
+
+- Bump `go.opentelemetry.io/otel/schema` to `0.0.17`
+  ([#481](https://github.com/open-telemetry/build-tools/pull/481))
+- Bump Go to `1.25` and Alpine to `3.23`
+  ([#425](https://github.com/open-telemetry/build-tools/pull/425), [#449](https://github.com/open-telemetry/build-tools/pull/449))
+
 ## v0.16.0
 
 - Update schema check tool to include bug fix #3777 in Otel Go.


### PR DESCRIPTION
prepare for a v0.26.0 release

NOTE: we want to release the proto builder, which does not have a CHANGELOG, but IIUC - we release BOTH images on release of this repo - so updating the changelog per CONTRIBUTING.md.