### PR TITLE
Fix rennovate config - Remove unused filter

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,10 +11,6 @@
         'patch',
         'minor',
       ],
-      excludeManagers: [
-        'github-actions',
-        'dockerfile',
-      ],
       schedule: [
         '* 0-7 * * 2', // weekly, before 8am on Tuesday
       ],


### PR DESCRIPTION
Fixes #498

Validated via the js-based validatior:

```
$ npx --yes --package renovate renovate-config-validator .github/renovate.json5
 INFO: Validating .github/renovate.json5 as global config
 INFO: Config validated successfully against 1 file(s)
 ```